### PR TITLE
Dynamically determine vehicle name for ROS

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "cwd": "${workspaceFolder}",
             "environment": [
             ],
-            "externalConsole": true,
+            "externalConsole": false,
             "MIMode": "gdb",
             "setupCommands": [
                 {

--- a/examples/ros/src/vehicle_control/src/vehicle_control.cpp
+++ b/examples/ros/src/vehicle_control/src/vehicle_control.cpp
@@ -76,6 +76,13 @@ void control_vehicle(){
 
 void state_sensor_callback(const monodrive_msgs::StateSensor &state_sensor_msg){
     state_data = state_sensor_msg;
+    for(auto& vehicle : state_data.vehicles) {
+        for(auto& tag : vehicle.tags) {
+            if(tag == "ego") {
+                vehicle_name = vehicle.name;
+            }
+        }
+    }
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
The shipping build creates a unique name for each vehicle that is spawned which
we rely on for controlling the vehicle. This will use the state sensor to query
the vehicle's name and use it to control it after its spawned.

To test, run the ROS example with the shipping build to see that it works.