### PR TITLE
Updated README with correct boost instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ Collection of monoDrive client software for different languages.
 ### Windows Library Dependencies
 Note: Extract or install these libraries to **C:/local** for cmake can find them.
 
-- [Boost](https://sourceforge.net/projects/boost/files/boost-binaries/1.73.0/boost_1_73_0-msvc-14.2-64.exe/download) Add `C:\local\boost_1_73_0\lib64-msvc-14.2` to your path.
+- [Boost](https://sourceforge.net/projects/boost/files/boost-binaries/1.73.0/boost_1_73_0-msvc-14.2-64.exe/download) 
+  - Add `C:\local\boost_1_73_0\lib64-msvc-14.2` to your PATH variable
+  - Create the `BOOST_ROOT` environment variable and set it to`C:\local\boost_1_73_0\lib64-msvc-14.2` 
 
 To build the examples the following are required:
-- [OpenCV](https://github.com/opencv/opencv/releases/download/4.3.0/opencv-4.3.0-vc14_vc15.exe) Extract to `C:\local\opencv` and add `C:\local\opencv\build\x64\vc15\bin` to your path.
-- [Eigen](https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip) Extract to `C:\local\Eigen3` and add `C:\local\Eigen3` to your path.
+- [OpenCV](https://github.com/opencv/opencv/releases/download/4.3.0/opencv-4.3.0-vc14_vc15.exe) Extract to `C:\local\opencv` and add `C:\local\opencv\build\x64\vc15\bin` to your PATH environment variable.
+- [Eigen](https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip) Extract to `C:\local\Eigen3` and add `C:\local\Eigen3` to your PATH environment variable.
 
  
 
@@ -133,3 +135,4 @@ If you are running the simulator and client on separate machines the following n
     ```bash
     rosrun simulator_control node
     ```
+

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Note: Extract or install these libraries to **C:/local** for cmake can find them
 
 - [Boost](https://sourceforge.net/projects/boost/files/boost-binaries/1.73.0/boost_1_73_0-msvc-14.2-64.exe/download) 
   - Add `C:\local\boost_1_73_0\lib64-msvc-14.2` to your PATH variable
-  - Create the `BOOST_ROOT` environment variable and set it to`C:\local\boost_1_73_0\lib64-msvc-14.2` 
+  - Create the `BOOST_ROOT` environment variable and set it to`C:\local\boost_1_73_0\` 
 
 To build the examples the following are required:
 - [OpenCV](https://github.com/opencv/opencv/releases/download/4.3.0/opencv-4.3.0-vc14_vc15.exe) Extract to `C:\local\opencv` and add `C:\local\opencv\build\x64\vc15\bin` to your PATH environment variable.


### PR DESCRIPTION
Users were not able to build the client because the BOOST_ROOT variable
was not properly set. This adds instructions for doing that.

Closes #35 