### PR TITLE
fix crash on client exit

### DIFF
--- a/monodrive/core/src/Simulator.cpp
+++ b/monodrive/core/src/Simulator.cpp
@@ -83,8 +83,8 @@ void Simulator::clearInstances()
 	std::lock_guard<std::mutex> simLock(_mutex);
 	for(auto& sim : simMap){
 		delete sim.second;
-		simMap.erase(sim.first);
 	}
+	simMap.clear();
 }
 
 void Simulator::connect()


### PR DESCRIPTION
This fixes a crash when calling `clearInstances()`. It is not safe to modify an stl container while iterating through it.