### PR TITLE
Waypoint Sensor data structure reorganization / left+right waypoints

### DIFF
--- a/examples/cpp/dev/CMakeLists.txt
+++ b/examples/cpp/dev/CMakeLists.txt
@@ -76,6 +76,7 @@ if(MSVC)
   add_dependencies(replay_step_dev monodrive_lib_copy_dev)
   add_dependencies(rpm_sensor monodrive_lib_copy_dev)
   add_dependencies(config_export monodrive_lib_copy_dev)
+  add_dependencies(waypoint_sensor monodrive_lib_copy_dev)
 endif(MSVC)
 
 # eigen

--- a/examples/cpp/dev/waypoint_sensor.cpp
+++ b/examples/cpp/dev/waypoint_sensor.cpp
@@ -53,19 +53,22 @@ int main(int argc, char** argv)
         auto& wpFrame = *static_cast<WaypointFrame*>(frame);
         for(const auto& actor : wpFrame.actor_waypoints) {
             std::cout << "Actor: " << actor.actor_id << " has " 
-                << actor.lanes.size() << " lanes." << std::endl;
+                << actor.lanes.size() << " lane(s)." << std::endl;
+            std::cout << "\tActor road: " << actor.actor_road_id 
+                        << " Actor lane: " << actor.actor_lane_id  << " - "
+                        << actor.actor_waypoint.distance << ", " 
+                        << actor.actor_waypoint.location.x << ", " 
+                        << actor.actor_waypoint.location.y << ", " 
+                        << actor.actor_waypoint.location.z << std::endl;
             for(const auto& lane : actor.lanes) {
                 if(lane.waypoints.size() >= 2) {
-                    std::cout << "WP 0: " 
-                        << lane.road_id << ", " 
-                        << lane.lane_id << ", "
+                    std::cout << "\tLane waypoints: " << lane.road_id << " - " << lane.lane_id << " Count: " << lane.waypoints.size() << std::endl;
+                    std::cout << "\t\tWP 0: " 
                         << lane.waypoints[0].distance << ", " 
                         << lane.waypoints[0].location.x << ", " 
                         << lane.waypoints[0].location.y << ", " 
                         << lane.waypoints[0].location.z << std::endl;
-                    std::cout << "WP 1: "
-                        << lane.road_id << ", " 
-                        << lane.lane_id << ", "
+                    std::cout << "\t\tWP 1: "
                         << lane.waypoints[1].distance << ", " 
                         << lane.waypoints[1].location.x << ", " 
                         << lane.waypoints[1].location.y << ", " 

--- a/examples/cpp/dev/waypoint_sensor.cpp
+++ b/examples/cpp/dev/waypoint_sensor.cpp
@@ -53,7 +53,25 @@ int main(int argc, char** argv)
         auto& wpFrame = *static_cast<WaypointFrame*>(frame);
         for(const auto& actor : wpFrame.actor_waypoints) {
             std::cout << "Actor: " << actor.actor_id << " has " 
-                << actor.waypoints.size() << " waypoints." << std::endl;
+                << actor.lanes.size() << " lanes." << std::endl;
+            for(const auto& lane : actor.lanes) {
+                if(lane.waypoints.size() >= 2) {
+                    std::cout << "WP 0: " 
+                        << lane.road_id << ", " 
+                        << lane.lane_id << ", "
+                        << lane.waypoints[0].distance << ", " 
+                        << lane.waypoints[0].location.x << ", " 
+                        << lane.waypoints[0].location.y << ", " 
+                        << lane.waypoints[0].location.z << std::endl;
+                    std::cout << "WP 1: "
+                        << lane.road_id << ", " 
+                        << lane.lane_id << ", "
+                        << lane.waypoints[1].distance << ", " 
+                        << lane.waypoints[1].location.x << ", " 
+                        << lane.waypoints[1].location.y << ", " 
+                        << lane.waypoints[1].location.z << std::endl;
+                }
+            }
         }
     };
 

--- a/examples/cpp/dev/waypoint_sensor.cpp
+++ b/examples/cpp/dev/waypoint_sensor.cpp
@@ -30,6 +30,8 @@ int main(int argc, char** argv)
     wp_config.server_ip = sim0.getServerIp();
     wp_config.server_port = sim0.getServerPort();
     wp_config.listen_port = 8102;
+    wp_config.distance = 10000;
+    wp_config.frequency = 100;
     sensors.push_back(std::make_shared<Sensor>(std::make_unique<WaypointConfig>(wp_config)));
 
     ViewportCameraConfig vp_config;

--- a/examples/ros/src/vehicle_control/src/vehicle_control.cpp
+++ b/examples/ros/src/vehicle_control/src/vehicle_control.cpp
@@ -93,6 +93,20 @@ void state_sensor_callback(const monodrive_msgs::StateSensor &state_sensor_msg){
 
 void waypoint_sensor_callback(const monodrive_msgs::WaypointSensor &waypoint_sensor_msg) {
     waypoint_data = waypoint_sensor_msg;
+    for(auto& actor : waypoint_data.actor_waypoints) {
+        std::cout << "Vehicle: " << actor.actor_id << " has " << 
+            actor.lanes.size() << " lanes" << std::endl;
+        for(auto& lane : actor.lanes) {
+            std::cout << "WP 0: " << lane.waypoints[0].distance << ", " << 
+                lane.waypoints[0].location.x << ", " << 
+                lane.waypoints[0].location.y << ", " << 
+                lane.waypoints[0].location.z << std::endl;
+            std::cout << "WP 1: " << lane.waypoints[1].distance << ", " << 
+                lane.waypoints[1].location.x << ", " << 
+                lane.waypoints[1].location.y << ", " << 
+                lane.waypoints[1].location.z << std::endl;
+        }
+    }
 }
 
 void imu_sensor_callback(const sensor_msgs::Imu &imu_sensor_msg) {

--- a/monodrive/core/src/DataFramePrimitives.cpp
+++ b/monodrive/core/src/DataFramePrimitives.cpp
@@ -234,7 +234,9 @@ void to_json(nlohmann::json& j, const ActorWaypoints& w){
 		{"actor_road_id", w.actor_road_id},
 		{"actor_lane_id", w.actor_lane_id},
 		{"actor_waypoint", w.actor_waypoint},
-		{"lanes", w.lanes}
+		{"lanes", w.lanes},
+		{"left_lanes", w.left_lanes},
+		{"right_lanes", w.right_lanes}
 	};
 }
 void from_json(const nlohmann::json& j, ActorWaypoints& w){
@@ -243,6 +245,8 @@ void from_json(const nlohmann::json& j, ActorWaypoints& w){
     json_get(j, "actor_lane_id", w.actor_lane_id); 
     json_get(j, "actor_waypoint", w.actor_waypoint); 
     json_get(j, "lanes", w.lanes); 
+    json_get(j, "left_lanes", w.left_lanes); 
+    json_get(j, "right_lanes", w.right_lanes); 
 }
 
 void to_json(nlohmann::json& j, const ActorLane& l){

--- a/monodrive/core/src/DataFramePrimitives.cpp
+++ b/monodrive/core/src/DataFramePrimitives.cpp
@@ -218,27 +218,42 @@ void to_json(nlohmann::json& j, const Waypoint& w){
 	j = {
 		{"location", w.location},
 		{"rotation", w.rotation},
-		{"road_id", w.road_id},
-		{"lane_id", w.lane_id},
 		{"distance", w.distance},
 		{"lane_change", w.lane_change}};
 }
 void from_json(const nlohmann::json& j, Waypoint& w){
     json_get(j, "location", w.location); 
     json_get(j, "rotation", w.rotation); 
-    json_get(j, "road_id", w.road_id); 
-    json_get(j, "lane_id", w.lane_id); 
     json_get(j, "distance", w.distance); 
     json_get(j, "lane_change", w.lane_change); 
 }
 
 void to_json(nlohmann::json& j, const ActorWaypoints& w){
 	j = {
-		{"id", w.actor_id},
-		{"waypoints", w.waypoints}
+		{"actor_id", w.actor_id},
+		{"actor_road_id", w.actor_road_id},
+		{"actor_lane_id", w.actor_lane_id},
+		{"actor_waypoint", w.actor_waypoint},
+		{"lanes", w.lanes}
 	};
 }
 void from_json(const nlohmann::json& j, ActorWaypoints& w){
-    json_get(j, "id", w.actor_id); 
-    json_get(j, "waypoints", w.waypoints); 
+    json_get(j, "actor_id", w.actor_id); 
+    json_get(j, "actor_road_id", w.actor_road_id); 
+    json_get(j, "actor_lane_id", w.actor_lane_id); 
+    json_get(j, "actor_waypoint", w.actor_waypoint); 
+    json_get(j, "lanes", w.lanes); 
+}
+
+void to_json(nlohmann::json& j, const ActorLane& l){
+	j = {
+		{"road_id", l.road_id},
+		{"lane_id", l.lane_id},
+		{"waypoints", l.waypoints}
+	};
+}
+void from_json(const nlohmann::json& j, ActorLane& l){
+    json_get(j, "road_id", l.road_id); 
+    json_get(j, "lane_id", l.lane_id); 
+    json_get(j, "waypoints", l.waypoints); 
 }

--- a/monodrive/core/src/DataFramePrimitives.h
+++ b/monodrive/core/src/DataFramePrimitives.h
@@ -150,6 +150,8 @@ struct ActorWaypoints {
     int actor_lane_id;
     Waypoint actor_waypoint;
     std::vector<ActorLane> lanes;
+    std::vector<ActorLane> left_lanes;
+    std::vector<ActorLane> right_lanes;
 };
 
 void MONODRIVECORE_API to_json(nlohmann::json& j, const Quat& v);

--- a/monodrive/core/src/DataFramePrimitives.h
+++ b/monodrive/core/src/DataFramePrimitives.h
@@ -134,15 +134,22 @@ enum LaneChange {
 struct Waypoint {
     Vec3f location;
     Vec3f rotation;
-    int road_id;
-    int lane_id;
     float distance;
     int lane_change;
 };
 
+struct ActorLane {
+    std::string road_id;
+    int lane_id;
+    std::vector<Waypoint> waypoints;
+};
+
 struct ActorWaypoints {
     std::string actor_id;
-    std::vector<Waypoint> waypoints;
+    std::string actor_road_id;
+    int actor_lane_id;
+    Waypoint actor_waypoint;
+    std::vector<ActorLane> lanes;
 };
 
 void MONODRIVECORE_API to_json(nlohmann::json& j, const Quat& v);
@@ -175,4 +182,6 @@ void MONODRIVECORE_API to_json(nlohmann::json& j, const Waypoint& v);
 void MONODRIVECORE_API from_json(const nlohmann::json& j, Waypoint& v);
 void MONODRIVECORE_API to_json(nlohmann::json& j, const ActorWaypoints& v);
 void MONODRIVECORE_API from_json(const nlohmann::json& j, ActorWaypoints& v);
+void MONODRIVECORE_API to_json(nlohmann::json& j, const ActorLane& v);
+void MONODRIVECORE_API from_json(const nlohmann::json& j, ActorLane& v);
 

--- a/monodrive/ros/src/monodrive_msgs/CMakeLists.txt
+++ b/monodrive/ros/src/monodrive_msgs/CMakeLists.txt
@@ -56,6 +56,7 @@ add_message_files(
   OOBB.msg
   VehicleControl.msg
   StateSensor.msg
+  ActorLane.msg
   ActorWaypoints.msg
   Waypoint.msg
   WaypointSensor.msg

--- a/monodrive/ros/src/monodrive_msgs/msg/ActorLane.msg
+++ b/monodrive/ros/src/monodrive_msgs/msg/ActorLane.msg
@@ -1,3 +1,3 @@
 string road_id
-int lane_id
+int32 lane_id
 monodrive_msgs/Waypoint[] waypoints

--- a/monodrive/ros/src/monodrive_msgs/msg/ActorLane.msg
+++ b/monodrive/ros/src/monodrive_msgs/msg/ActorLane.msg
@@ -1,0 +1,3 @@
+string road_id
+int lane_id
+monodrive_msgs/Waypoint[] waypoints

--- a/monodrive/ros/src/monodrive_msgs/msg/ActorWaypoints.msg
+++ b/monodrive/ros/src/monodrive_msgs/msg/ActorWaypoints.msg
@@ -1,2 +1,5 @@
 string actor_id
+string actor_road_id
+int actor_lane_id
+monodrive_msgs/Waypoint actor_waypoint
 monodrive_msgs/Waypoint[] waypoints

--- a/monodrive/ros/src/monodrive_msgs/msg/ActorWaypoints.msg
+++ b/monodrive/ros/src/monodrive_msgs/msg/ActorWaypoints.msg
@@ -3,3 +3,5 @@ string actor_road_id
 int32 actor_lane_id
 monodrive_msgs/Waypoint actor_waypoint
 monodrive_msgs/ActorLane[] lanes
+monodrive_msgs/ActorLane[] left_lanes
+monodrive_msgs/ActorLane[] right_lanes

--- a/monodrive/ros/src/monodrive_msgs/msg/ActorWaypoints.msg
+++ b/monodrive/ros/src/monodrive_msgs/msg/ActorWaypoints.msg
@@ -1,5 +1,5 @@
 string actor_id
 string actor_road_id
-int actor_lane_id
+int32 actor_lane_id
 monodrive_msgs/Waypoint actor_waypoint
-monodrive_msgs/Waypoint[] waypoints
+monodrive_msgs/ActorLane[] lanes


### PR DESCRIPTION
This implements the waypoint sensor data structure reorganization as discussed the meeting on 7 July. The waypoint sensor now produces data that contains every actors:

* Own "ActorLanes" which is a list of lanes with road id, lane id, and a list of waypoints for that lane. This list will extend out to the desired distance (radius) given during configuration
* Left and right "ActorLanes" out to the raidus
* The current road id, lane id, and waypoint the actor is on

Additionally,  the redundant road id and lane id have been removed from the actual waypoint data structure.