### PR TITLE
Revert "Update with latest state sensor and ROS fixes"

### DIFF
--- a/examples/cpp/dev/CMakeLists.txt
+++ b/examples/cpp/dev/CMakeLists.txt
@@ -76,7 +76,6 @@ if(MSVC)
   add_dependencies(replay_step_dev monodrive_lib_copy_dev)
   add_dependencies(rpm_sensor monodrive_lib_copy_dev)
   add_dependencies(config_export monodrive_lib_copy_dev)
-  add_dependencies(waypoint_sensor monodrive_lib_copy_dev)
 endif(MSVC)
 
 # eigen

--- a/examples/cpp/dev/waypoint_sensor.cpp
+++ b/examples/cpp/dev/waypoint_sensor.cpp
@@ -30,8 +30,6 @@ int main(int argc, char** argv)
     wp_config.server_ip = sim0.getServerIp();
     wp_config.server_port = sim0.getServerPort();
     wp_config.listen_port = 8102;
-    wp_config.distance = 10000;
-    wp_config.frequency = 100;
     sensors.push_back(std::make_shared<Sensor>(std::make_unique<WaypointConfig>(wp_config)));
 
     ViewportCameraConfig vp_config;
@@ -55,28 +53,7 @@ int main(int argc, char** argv)
         auto& wpFrame = *static_cast<WaypointFrame*>(frame);
         for(const auto& actor : wpFrame.actor_waypoints) {
             std::cout << "Actor: " << actor.actor_id << " has " 
-                << actor.lanes.size() << " lane(s)." << std::endl;
-            std::cout << "\tActor road: " << actor.actor_road_id 
-                        << " Actor lane: " << actor.actor_lane_id  << " - "
-                        << actor.actor_waypoint.distance << ", " 
-                        << actor.actor_waypoint.location.x << ", " 
-                        << actor.actor_waypoint.location.y << ", " 
-                        << actor.actor_waypoint.location.z << std::endl;
-            for(const auto& lane : actor.lanes) {
-                if(lane.waypoints.size() >= 2) {
-                    std::cout << "\tLane waypoints: " << lane.road_id << " - " << lane.lane_id << " Count: " << lane.waypoints.size() << std::endl;
-                    std::cout << "\t\tWP 0: " 
-                        << lane.waypoints[0].distance << ", " 
-                        << lane.waypoints[0].location.x << ", " 
-                        << lane.waypoints[0].location.y << ", " 
-                        << lane.waypoints[0].location.z << std::endl;
-                    std::cout << "\t\tWP 1: "
-                        << lane.waypoints[1].distance << ", " 
-                        << lane.waypoints[1].location.x << ", " 
-                        << lane.waypoints[1].location.y << ", " 
-                        << lane.waypoints[1].location.z << std::endl;
-                }
-            }
+                << actor.waypoints.size() << " waypoints." << std::endl;
         }
     };
 

--- a/examples/ros/src/simulator_control/src/simulator_control.cpp
+++ b/examples/ros/src/simulator_control/src/simulator_control.cpp
@@ -54,16 +54,6 @@ std::vector<std::shared_ptr<Sensor>> create_sensors_for(const Simulator& sim0)
     waypoint_config.ros.message_type = "monodrive_msgs/WaypointSensor";
     sensors.push_back(std::make_shared<Sensor>(std::make_unique<WaypointConfig>(waypoint_config)));
 
-    IMUConfig imu_config;
-    imu_config.server_ip = sim0.getServerIp();
-    imu_config.server_port = sim0.getServerPort();
-    imu_config.listen_port = 8102;
-    imu_config.ros.publish_to_ros = true;
-    imu_config.ros.advertise = true;
-    imu_config.ros.topic = "/monodrive/imu_sensor";
-    imu_config.ros.message_type = "sensor_msgs/Imu";
-    sensors.push_back(std::make_shared<Sensor>(std::make_unique<IMUConfig>(imu_config)));
-
     std::cout<<"***********ALL SENSOR CONFIGS*******"<<std::endl;
     for (auto& sensor : sensors)
     {

--- a/examples/ros/src/vehicle_control/src/vehicle_control.cpp
+++ b/examples/ros/src/vehicle_control/src/vehicle_control.cpp
@@ -10,7 +10,6 @@
 
 #include "ros/ros.h"
 #include "ros/package.h"
-#include "sensor_msgs/Imu.h"
 #include "monodrive_msgs/VehicleControl.h"
 #include "monodrive_msgs/StateSensor.h"
 #include "monodrive_msgs/WaypointSensor.h"
@@ -28,11 +27,9 @@ std::shared_ptr<ros::NodeHandle> node_handle;
 ros::Publisher vehicle_control_pub;
 ros::Subscriber state_sensor_sub;
 ros::Subscriber wp_sensor_sub;
-ros::Subscriber imu_sensor_sub;
 
 monodrive_msgs::StateSensor state_data;
 monodrive_msgs::WaypointSensor waypoint_data;
-sensor_msgs::Imu imu_data;
 
 void control_vehicle(){
     monodrive_msgs::VehicleState vs;
@@ -42,14 +39,14 @@ void control_vehicle(){
         }
     }
     Eigen::VectorXd position(3);
-    position << vs.pose.pose.position.x,
-        vs.pose.pose.position.y,
-        vs.pose.pose.position.z;
+    position << vs.odometry.pose.pose.position.x,
+        vs.odometry.pose.pose.position.y,
+        vs.odometry.pose.pose.position.z;
     Eigen::Quaternion<double> orientation(
-        vs.pose.pose.orientation.w,
-        vs.pose.pose.orientation.x,
-        vs.pose.pose.orientation.y,
-        vs.pose.pose.orientation.z
+        vs.odometry.pose.pose.orientation.w,
+        vs.odometry.pose.pose.orientation.x,
+        vs.odometry.pose.pose.orientation.y,
+        vs.odometry.pose.pose.orientation.z
     );
 
     auto nearestIndex = lanespline.GetNearestPoint("road_0", "lane_2", position);
@@ -93,24 +90,6 @@ void state_sensor_callback(const monodrive_msgs::StateSensor &state_sensor_msg){
 
 void waypoint_sensor_callback(const monodrive_msgs::WaypointSensor &waypoint_sensor_msg) {
     waypoint_data = waypoint_sensor_msg;
-    for(auto& actor : waypoint_data.actor_waypoints) {
-        std::cout << "Vehicle: " << actor.actor_id << " has " << 
-            actor.lanes.size() << " lanes" << std::endl;
-        for(auto& lane : actor.lanes) {
-            std::cout << "WP 0: " << lane.waypoints[0].distance << ", " << 
-                lane.waypoints[0].location.x << ", " << 
-                lane.waypoints[0].location.y << ", " << 
-                lane.waypoints[0].location.z << std::endl;
-            std::cout << "WP 1: " << lane.waypoints[1].distance << ", " << 
-                lane.waypoints[1].location.x << ", " << 
-                lane.waypoints[1].location.y << ", " << 
-                lane.waypoints[1].location.z << std::endl;
-        }
-    }
-}
-
-void imu_sensor_callback(const sensor_msgs::Imu &imu_sensor_msg) {
-    imu_data = imu_sensor_msg;
 }
 
 int main(int argc, char** argv)
@@ -129,8 +108,6 @@ int main(int argc, char** argv)
         &state_sensor_callback);
     wp_sensor_sub = node_handle->subscribe("/monodrive/waypoint_sensor", 1, 
         &waypoint_sensor_callback);
-    imu_sensor_sub = node_handle->subscribe("/monodrive/imu_sensor", 1, 
-        &imu_sensor_callback);
 
     ros::Rate rate(100);
 

--- a/monodrive/core/src/DataFramePrimitives.cpp
+++ b/monodrive/core/src/DataFramePrimitives.cpp
@@ -218,46 +218,27 @@ void to_json(nlohmann::json& j, const Waypoint& w){
 	j = {
 		{"location", w.location},
 		{"rotation", w.rotation},
+		{"road_id", w.road_id},
+		{"lane_id", w.lane_id},
 		{"distance", w.distance},
 		{"lane_change", w.lane_change}};
 }
 void from_json(const nlohmann::json& j, Waypoint& w){
     json_get(j, "location", w.location); 
     json_get(j, "rotation", w.rotation); 
+    json_get(j, "road_id", w.road_id); 
+    json_get(j, "lane_id", w.lane_id); 
     json_get(j, "distance", w.distance); 
     json_get(j, "lane_change", w.lane_change); 
 }
 
 void to_json(nlohmann::json& j, const ActorWaypoints& w){
 	j = {
-		{"actor_id", w.actor_id},
-		{"actor_road_id", w.actor_road_id},
-		{"actor_lane_id", w.actor_lane_id},
-		{"actor_waypoint", w.actor_waypoint},
-		{"lanes", w.lanes},
-		{"left_lanes", w.left_lanes},
-		{"right_lanes", w.right_lanes}
+		{"id", w.actor_id},
+		{"waypoints", w.waypoints}
 	};
 }
 void from_json(const nlohmann::json& j, ActorWaypoints& w){
-    json_get(j, "actor_id", w.actor_id); 
-    json_get(j, "actor_road_id", w.actor_road_id); 
-    json_get(j, "actor_lane_id", w.actor_lane_id); 
-    json_get(j, "actor_waypoint", w.actor_waypoint); 
-    json_get(j, "lanes", w.lanes); 
-    json_get(j, "left_lanes", w.left_lanes); 
-    json_get(j, "right_lanes", w.right_lanes); 
-}
-
-void to_json(nlohmann::json& j, const ActorLane& l){
-	j = {
-		{"road_id", l.road_id},
-		{"lane_id", l.lane_id},
-		{"waypoints", l.waypoints}
-	};
-}
-void from_json(const nlohmann::json& j, ActorLane& l){
-    json_get(j, "road_id", l.road_id); 
-    json_get(j, "lane_id", l.lane_id); 
-    json_get(j, "waypoints", l.waypoints); 
+    json_get(j, "id", w.actor_id); 
+    json_get(j, "waypoints", w.waypoints); 
 }

--- a/monodrive/core/src/DataFramePrimitives.h
+++ b/monodrive/core/src/DataFramePrimitives.h
@@ -134,24 +134,15 @@ enum LaneChange {
 struct Waypoint {
     Vec3f location;
     Vec3f rotation;
+    int road_id;
+    int lane_id;
     float distance;
     int lane_change;
 };
 
-struct ActorLane {
-    std::string road_id;
-    int lane_id;
-    std::vector<Waypoint> waypoints;
-};
-
 struct ActorWaypoints {
     std::string actor_id;
-    std::string actor_road_id;
-    int actor_lane_id;
-    Waypoint actor_waypoint;
-    std::vector<ActorLane> lanes;
-    std::vector<ActorLane> left_lanes;
-    std::vector<ActorLane> right_lanes;
+    std::vector<Waypoint> waypoints;
 };
 
 void MONODRIVECORE_API to_json(nlohmann::json& j, const Quat& v);
@@ -184,6 +175,4 @@ void MONODRIVECORE_API to_json(nlohmann::json& j, const Waypoint& v);
 void MONODRIVECORE_API from_json(const nlohmann::json& j, Waypoint& v);
 void MONODRIVECORE_API to_json(nlohmann::json& j, const ActorWaypoints& v);
 void MONODRIVECORE_API from_json(const nlohmann::json& j, ActorWaypoints& v);
-void MONODRIVECORE_API to_json(nlohmann::json& j, const ActorLane& v);
-void MONODRIVECORE_API from_json(const nlohmann::json& j, ActorLane& v);
 

--- a/monodrive/ros/src/monodrive_msgs/CMakeLists.txt
+++ b/monodrive/ros/src/monodrive_msgs/CMakeLists.txt
@@ -56,7 +56,6 @@ add_message_files(
   OOBB.msg
   VehicleControl.msg
   StateSensor.msg
-  ActorLane.msg
   ActorWaypoints.msg
   Waypoint.msg
   WaypointSensor.msg

--- a/monodrive/ros/src/monodrive_msgs/msg/ActorLane.msg
+++ b/monodrive/ros/src/monodrive_msgs/msg/ActorLane.msg
@@ -1,3 +1,0 @@
-string road_id
-int32 lane_id
-monodrive_msgs/Waypoint[] waypoints

--- a/monodrive/ros/src/monodrive_msgs/msg/ActorWaypoints.msg
+++ b/monodrive/ros/src/monodrive_msgs/msg/ActorWaypoints.msg
@@ -1,7 +1,2 @@
 string actor_id
-string actor_road_id
-int32 actor_lane_id
-monodrive_msgs/Waypoint actor_waypoint
-monodrive_msgs/ActorLane[] lanes
-monodrive_msgs/ActorLane[] left_lanes
-monodrive_msgs/ActorLane[] right_lanes
+monodrive_msgs/Waypoint[] waypoints

--- a/monodrive/ros/src/monodrive_msgs/msg/VehicleState.msg
+++ b/monodrive/ros/src/monodrive_msgs/msg/VehicleState.msg
@@ -1,6 +1,5 @@
 string name
-geometry_msgs/PoseWithCovariance pose
-geometry_msgs/TwistWithCovariance twist
+nav_msgs/Odometry odometry
 string[] tags
 monodrive_msgs/WheelState[] wheels
 monodrive_msgs/OOBB[] oobbs


### PR DESCRIPTION
Reverts monoDriveIO/monodrive-client#54

This rolls back the master branch to 1.11 support.