### PR TITLE
Removed unused fields from waypoint

### DIFF
--- a/monodrive/ros/src/monodrive_msgs/msg/Waypoint.msg
+++ b/monodrive/ros/src/monodrive_msgs/msg/Waypoint.msg
@@ -1,5 +1,3 @@
-int32 road_id
-int32 lane_id
 int32 lane_change
 float64 distance
 geometry_msgs/Vector3 location


### PR DESCRIPTION
Removes unused fields from Waypoint Sensor's ROS Waypoint data structure. These were causing confusion and creating some issues with the way that the Waypoint Sensor was streaming to ROS.