### PR TITLE
Remove left/right indicators from auto pilot

### DIFF
--- a/examples/cpp/dev/autopilot_control.cpp
+++ b/examples/cpp/dev/autopilot_control.cpp
@@ -50,8 +50,6 @@ int main(int argc, char** argv)
     apc_config.lane_change = 2; // Request to change lanes (2 - both ways)
     apc_config.autopilot_engaged = true; // Autopilot control is allowed
     apc_config.gear = "D1"; // Gear indicator
-    apc_config.left_lane_change = false; // Left lane change indicator
-    apc_config.right_lane_change = true; // Right lane change indicator
     apc_config.manual_override = false; // Manual override indicator
     sim0.sendCommand(apc_config.message());
 


### PR DESCRIPTION
This was missed in the last PR, but now the auto pilot example will
build and run.