### PR TITLE
Added explicit warnings for missing config files

### DIFF
--- a/monodrive/core/src/Configuration.cpp
+++ b/monodrive/core/src/Configuration.cpp
@@ -32,12 +32,18 @@ nlohmann::json Configuration::load(const std::string& path)
     try
     {
         std::ifstream in(path, std::ifstream::in);
-        in >> j;
-        in.close();
+        if(in.is_open()) {
+            in >> j;
+            in.close();
+        } else {
+            std::cerr << "WARNING! Unable to read configuration file at: " 
+                << path << std::endl;
+        }
     }
     catch(std::exception& e)
     {
-        std::cout << e.what() << std::endl;
+        std::cerr << "WARNING! Exception thrown when parsing file: " << path << std::endl;
+        std::cerr << e.what() << std::endl;
     }
 	
 	return j;

--- a/monodrive/core/src/Simulator.cpp
+++ b/monodrive/core/src/Simulator.cpp
@@ -108,7 +108,7 @@ bool Simulator::connect()
 		controlSocket.connect(endpoint);
 		}
 		catch (const std::exception& e){
-			std::cout << "Failed to connect to server. Is it running?" << std::endl;
+			std::cerr << "ERROR! Failed to connect to server. Is it running?" << std::endl;
 			std::cerr << e.what() << std::endl;
 			return false;
 		}
@@ -132,7 +132,7 @@ bool Simulator::configure()
 
 	if(config.simulator.empty())
 	{
-		std::cout << "Skipping Simulator and Scenario Config, no simulator config set." << std::endl;
+		std::cerr << "WARNING! Skipping Simulator and Scenario Config, no simulator config set." << std::endl;
 	}
 	else
 	{
@@ -159,7 +159,7 @@ bool Simulator::configure()
 
 	if (config.weather.empty())
 	{
-		std::cout << "Skipping Weather Config, no weather config set." << std::endl;
+		std::cerr << "WARNING! Skipping Weather Config, no weather config set." << std::endl;
 	}
 	else
 	{
@@ -246,7 +246,7 @@ bool Simulator::sampleAll(std::vector<std::shared_ptr<Sensor>>& sensors)
 		waitForSamples(sensors);
 	}
 	else{
-		std::cerr << "Failed to sample sensors." << std::endl;
+		std::cerr << "ERROR! Failed to sample sensors." << std::endl;
 		return false;
 	}
 	return true;
@@ -266,7 +266,7 @@ bool Simulator::sampleSensorList(std::vector<std::shared_ptr<Sensor>>& sensors)
 		waitForSamples(sensors);
 	}
 	else{
-		std::cerr << "Failed to sample sensors." << std::endl;
+		std::cerr << "ERROR! Failed to sample sensors." << std::endl;
 		return false;
 	}
 	return true;

--- a/monodrive/core/src/Simulator.cpp
+++ b/monodrive/core/src/Simulator.cpp
@@ -132,7 +132,7 @@ bool Simulator::configure()
 
 	if(config.simulator.empty())
 	{
-		std::cout << "WARNING! Skipping Simulator and Scenario Config, no simulator config set." << std::endl;
+		std::cout << "Skipping Simulator and Scenario Config, no simulator config set." << std::endl;
 	}
 	else
 	{
@@ -159,7 +159,7 @@ bool Simulator::configure()
 
 	if (config.weather.empty())
 	{
-		std::cout << "WARNING! Skipping Weather Config, no weather config set." << std::endl;
+		std::cout << "Skipping Weather Config, no weather config set." << std::endl;
 	}
 	else
 	{

--- a/monodrive/core/src/Simulator.cpp
+++ b/monodrive/core/src/Simulator.cpp
@@ -132,7 +132,7 @@ bool Simulator::configure()
 
 	if(config.simulator.empty())
 	{
-		std::cerr << "WARNING! Skipping Simulator and Scenario Config, no simulator config set." << std::endl;
+		std::cout << "WARNING! Skipping Simulator and Scenario Config, no simulator config set." << std::endl;
 	}
 	else
 	{
@@ -159,7 +159,7 @@ bool Simulator::configure()
 
 	if (config.weather.empty())
 	{
-		std::cerr << "WARNING! Skipping Weather Config, no weather config set." << std::endl;
+		std::cout << "WARNING! Skipping Weather Config, no weather config set." << std::endl;
 	}
 	else
 	{


### PR DESCRIPTION
This will help better debug when paths are wrong to configuration files
in the C++ client. Now we echo errors and warnings to std error when a
file is missing.