### PR TITLE
Added configuration and demo for waypoint debug

### DIFF
--- a/examples/cpp/dev/waypoint_sensor.cpp
+++ b/examples/cpp/dev/waypoint_sensor.cpp
@@ -54,7 +54,6 @@ int main(int argc, char** argv)
     sim0.sendControl(0.1, 0.0, 0.0, 1);
 
     sensors[0]->sampleCallback = [](DataFrame* frame){
-        return;
         auto& wpFrame = *static_cast<WaypointFrame*>(frame);
         for(const auto& actor : wpFrame.actor_waypoints) {
             std::cout << "Actor: " << actor.actor_id << " has " 

--- a/examples/cpp/dev/waypoint_sensor.cpp
+++ b/examples/cpp/dev/waypoint_sensor.cpp
@@ -32,6 +32,8 @@ int main(int argc, char** argv)
     wp_config.listen_port = 8102;
     wp_config.distance = 10000;
     wp_config.frequency = 100;
+    wp_config.draw_debug = true;
+    wp_config.debug_tags = {"ego"};
     sensors.push_back(std::make_shared<Sensor>(std::make_unique<WaypointConfig>(wp_config)));
 
     ViewportCameraConfig vp_config;
@@ -52,6 +54,7 @@ int main(int argc, char** argv)
     sim0.sendControl(0.1, 0.0, 0.0, 1);
 
     sensors[0]->sampleCallback = [](DataFrame* frame){
+        return;
         auto& wpFrame = *static_cast<WaypointFrame*>(frame);
         for(const auto& actor : wpFrame.actor_waypoints) {
             std::cout << "Actor: " << actor.actor_id << " has " 

--- a/monodrive/core/src/sensor_config.h
+++ b/monodrive/core/src/sensor_config.h
@@ -308,6 +308,8 @@ public:
 
     float distance = 1000.0;
     float frequency = 100.0;
+    bool draw_debug = false;
+    std::vector<std::string> debug_tags{};
 };
 
 class RPMConfig : public SensorBaseConfig
@@ -788,10 +790,14 @@ void inline to_json(nlohmann::json& j, const WaypointConfig& config) {
     j = static_cast<SensorBaseConfig>(config);
     j["distance"] = config.distance;
     j["frequency"] = config.frequency;
+    j["draw_debug"] = config.draw_debug;
+    j["debug_tags"] = config.debug_tags;
 
 }
 void inline from_json(const nlohmann::json& j, WaypointConfig& config) {
     json_get(j, "distance", config.distance);
     json_get(j, "frequency", config.frequency);
+    json_get(j, "draw_debug", config.draw_debug);
+    json_get(j, "debug_tags", config.debug_tags);
 }
 /// END Waypoint Sensor JSON parsing


### PR DESCRIPTION
This adds the configuration values and an example of how to use the
waypoint sensor's debug drawing features. Similar to the state sensor or
collision sensor, there is a list of actor tags `debug_tags` that needs
to be populated in the waypoint sensor. Anything in this list that has
waypoints will draw debug waypoints if the `draw_debug` flag is set.

Closes #69 