### PR TITLE
Distributed architecture client for benchmarking

### DIFF
--- a/examples/config/simulator_straightaway_replay.json
+++ b/examples/config/simulator_straightaway_replay.json
@@ -1,0 +1,107 @@
+{
+  "id": "simulator_test",
+  "server_ip": "127.0.0.1",
+  "server_port": 8999,
+  "client_ip": "127.0.0.1",
+  "map": "Straightaway5k",
+  "phys_materials": {
+    "Aluminum": {
+      "specular_exponent": 15.0,
+      "specular_coefficient": 0.95,
+      "diffuse_coefficient": 0.26,
+      "dielectric_constant": 10.0,
+      "roughness": 0.15
+    },
+    "Asphalt": {
+      "specular_exponent": 1.0,
+      "specular_coefficient": 0.03,
+      "diffuse_coefficient": 0.65,
+      "dielectric_constant": 7.0,
+      "roughness": 0.65
+    },
+    "Road": {
+      "specular_exponent": 1.0,
+      "specular_coefficient": 0.1,
+      "diffuse_coefficient": 0.65,
+      "dielectric_constant": 7.0,
+      "roughness": 0.65
+    },
+    "Concrete": {
+      "specular_exponent": 0.0,
+      "specular_coefficient": 0.1,
+      "diffuse_coefficient": 0.65,
+      "dielectric_constant": 7.0,
+      "roughness": 0.0
+    },
+    "Glass": {
+      "specular_exponent": 80.0,
+      "specular_coefficient": 0.80,
+      "diffuse_coefficient": 0.15,
+      "dielectric_constant": 4.0,
+      "roughness": 0.10
+    },
+    "LandScape": {
+      "specular_exponent": 10.0,
+      "specular_coefficient": 0.50,
+      "diffuse_coefficient": 0.50,
+      "dielectric_constant": 10.0,
+      "roughness": 0.60
+    },
+    "Plastic": {
+      "specular_exponent": 25.0,
+      "specular_coefficient": 0.40,
+      "diffuse_coefficient": 0.60,
+      "dielectric_constant": 2.8,
+      "roughness": 0.09
+    },
+    "Steel": {
+      "specular_exponent": 26.0,
+      "specular_coefficient": 1.0,
+      "diffuse_coefficient": 0.33,
+      "dielectric_constant": 0.0,
+      "roughness": 0.23
+    },
+    "Tree": {
+      "specular_exponent": 10.0,
+      "specular_coefficient": 0.05,
+      "diffuse_coefficient": 0.97,
+      "dielectric_constant": 10.0,
+      "roughness": 0.60
+    },
+    "Wheel": {
+      "specular_exponent": 92.0,
+      "specular_coefficient": 0.95,
+      "diffuse_coefficient": 0.06,
+      "dielectric_constant": 10.0,
+      "roughness": 0.15
+    },
+    "Tire": {
+      "specular_exponent": 25.0,
+      "specular_coefficient": 0.40,
+      "diffuse_coefficient": 0.60,
+      "dielectric_constant": 2.8,
+      "roughness": 0.15
+    }
+  },
+  "traffic_configuration": {
+    "max_vehicles": 0,
+    "spawn_rate": 0.25
+  },
+  "client_settings": {
+    "map": {
+      "gis_anchor": { "x": 0, "y": 0, "z": 0},
+      "point_delta": 100.0
+    },
+    "gui":{
+      "fps": 1.0
+    },
+    "logger": {
+      "sensor": "debug",
+      "network": "info",
+      "control": "info",
+      "scenario": "info",
+      "simulator": "info",
+      "vehicle": "info"
+    }
+  }
+}

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -19,3 +19,4 @@ endif()
 
 add_subdirectory(replay)
 add_subdirectory(replay_step)
+add_subdirectory(distributed)

--- a/examples/cpp/distributed/CMakeLists.txt
+++ b/examples/cpp/distributed/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(distributed)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(distributed distributed.cpp)
+
+target_link_libraries(distributed monodrive)
+
+# copy dll to runtime directory
+if(MSVC)
+  add_custom_target(monodrive_lib_copy_distributed)
+  add_custom_command(TARGET monodrive_lib_copy_distributed POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      $<TARGET_FILE:monodrive>
+      ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/monodrive.dll
+  )
+  add_dependencies(distributed monodrive_lib_copy_distributed)
+endif(MSVC)

--- a/examples/cpp/distributed/CMakeLists.txt
+++ b/examples/cpp/distributed/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_executable(distributed distributed.cpp)
+add_executable(distributed distributed.cpp  distributed_server.cpp)
 
 target_link_libraries(distributed monodrive)
 

--- a/examples/cpp/distributed/distributed.cpp
+++ b/examples/cpp/distributed/distributed.cpp
@@ -1,0 +1,107 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <utility>
+#include <chrono>
+
+#include "Simulator.h"
+#include "Configuration.h"
+#include "Sensor.h"
+#include "sensor_config.h"
+
+
+nlohmann::json CURRENT_STATE_FRAME = nullptr;
+bool NEW_STATE_DATA_AVAILABLE = false;
+
+void stateCallback(DataFrame* frame) {
+    auto& state_frame = *static_cast<StateFrame*>(frame);
+    CURRENT_STATE_FRAME = {
+        {"frame", 
+            {
+                {"vehicles", state_frame.vehicles}, 
+                {"objects", state_frame.objects}
+            }
+        }
+    };
+    NEW_STATE_DATA_AVAILABLE = true;
+};
+
+typedef std::vector<std::shared_ptr<Sensor>> sensor_vec;
+
+int main(int argc, char** argv) {
+    // Read in JSON files for simulator configuration
+    Configuration config(
+        "examples/config/simulator.json",
+        "examples/config/weather.json",
+        "examples/config/scenario.json"
+    );
+
+    // Setup the list of simulators that will be used
+    std::vector<std::pair<Simulator*, sensor_vec>> server_list = {
+        std::make_pair(
+            &Simulator::getInstance(config, "192.168.2.3", 8999), 
+            sensor_vec()),
+        std::make_pair(
+            &Simulator::getInstance(config, "192.168.2.3", 9000), 
+            sensor_vec())
+    };
+
+    // Setup all the sensors for each server in the list
+    for(auto& server : server_list) {
+        if(!server.first->configure()) {
+            std::cerr << "ERROR! Unable to configure simulator: " 
+                << server.first->getServerIp() << ":" 
+                << server.first->getServerPort()
+                << std::endl;
+            return -1;
+        }
+
+        if(server.first->getServerPort() == 8999) {
+            StateConfig s_config;
+            s_config.server_ip = server.first->getServerIp();
+            s_config.server_port = server.first->getServerPort();
+            s_config.listen_port = 8101;
+            s_config.desired_tags = {"vehicle", "dynamic"};
+            s_config.include_obb = false;
+            s_config.debug_drawing = true;
+            server.second.emplace_back(std::make_shared<Sensor>(
+                std::make_unique<StateConfig>(s_config)));
+            server.second.back()->sampleCallback = stateCallback;
+        }
+
+        ViewportCameraConfig vp_config;
+        vp_config.server_ip = server.first->getServerIp();
+        vp_config.server_port = server.first->getServerPort();
+        vp_config.location.z = 200;
+        vp_config.resolution = Resolution(256,256);
+        Sensor(std::make_unique<ViewportCameraConfig>(vp_config)).configure();
+
+        for(auto& sensor : server.second) {
+            if(!sensor->configure()) {
+                std::cerr << "ERROR! Unable to configure sensor "
+                          << sensor->config->type << " on port " 
+                          << sensor->config->listen_port << " for server "
+                          << server.first->getServerIp() << ":" 
+                          << server.first->getServerPort() << std::endl;
+                return -1;
+            }
+        }
+    }
+
+    std::cout << "Sampling sensor loop" << std::endl;
+    for(int step = 0; step < config.scenario.size(); step++) {
+        server_list[0].first->stepSampleAll(server_list[0].second, step, 1);
+        // Spin while we're waiting on the new state data to come in
+        while(!NEW_STATE_DATA_AVAILABLE) {
+            std::this_thread::sleep_for(std::chrono::nanoseconds(1));
+        }
+        NEW_STATE_DATA_AVAILABLE = false;
+        std::cout << "Sending frame:" << CURRENT_STATE_FRAME << std::endl;
+        for(size_t i = 1; i < server_list.size(); i++) {
+            server_list[i].first->stateStepSampleAll(server_list[i].second, 
+                CURRENT_STATE_FRAME);
+        }
+    }
+
+    return 0;
+}

--- a/examples/cpp/distributed/distributed_server.cpp
+++ b/examples/cpp/distributed/distributed_server.cpp
@@ -1,0 +1,155 @@
+#include <functional>
+
+#include "distributed_server.h"
+
+using namespace distributed_server;
+
+DistributedServer::DistributedServer(const std::string& ip_address,
+                                     const int& port,
+                                     const kServerType& server_type)
+    : server_type(server_type) {
+  // Go ahead and grab an instance of the server before configuring
+  sim = &Simulator::getInstance(
+      server_type == kServerType::PRIMARY ? kPrimaryConfig : kReplicaConfig, 
+      ip_address, port);
+
+  // All server ports are technically reserved as well
+  kServerReservedPorts.insert(port);
+}
+
+bool DistributedServer::Configure(const std::vector<kSensorType>& sensor_types){
+  // Configure the simulator
+  sensors.clear();
+  if (!sim->configure()) {
+    std::cerr << "DistributedServer::Configure: ERROR! Unable to configure "
+                 "simulator: "
+              << sim->getServerIp() << ":" << sim->getServerPort() << std::endl;
+    return false;
+  }
+
+  // Configure all the sensors for the simulator
+  for(auto& sensor : sensor_types) {
+      if(!AddSensor(sensor)) {
+        std::cerr << "DistributedServer::Configure: ERROR! Unable to configure "
+                     "sensor type "
+                  << sensor << " on server: " << sim->getServerIp() << ":"
+                  << sim->getServerPort() << std::endl;
+        return false;
+      }
+  }
+  return true;
+}
+
+bool DistributedServer::AddSensor(kSensorType sensor_type) {
+  // Go through all the reserved ports and make a reservation for this sensor
+  int listen_port = 8101;
+  while (kServerReservedPorts.count(listen_port)) {
+    listen_port += 1;
+  }
+  kServerReservedPorts.insert(listen_port);
+
+  // Choose from one of our many preconfigured sensors!
+  switch (sensor_type) {
+    case kSensorType::BINARY_STATE: {
+      StateConfig s_config;
+      s_config.server_ip = sim->getServerIp();
+      s_config.server_port = sim->getServerPort();
+      s_config.listen_port = listen_port;
+      s_config.desired_tags = {"vehicle", "dynamic"};
+      s_config.include_obb = false;
+      s_config.debug_drawing = true;
+      s_config.send_binary_frame = true;
+      sensors.emplace_back(
+          std::make_shared<Sensor>(std::make_unique<StateConfig>(s_config)));
+      sensors.back()->sampleCallback = std::bind(
+          &DistributedServer::StateSensorCallback, this, std::placeholders::_1);
+    } break;
+    case kSensorType::VIEWPORT: {
+      ViewportCameraConfig vp_config;
+      vp_config.server_ip = sim->getServerIp();
+      vp_config.server_port = sim->getServerPort();
+      vp_config.location.z = 200;
+      vp_config.resolution = Resolution(256, 256);
+      Sensor(std::make_unique<ViewportCameraConfig>(vp_config)).configure();
+    } break;
+    case kSensorType::RADAR: {
+      RadarConfig r_config;
+      r_config.server_ip = sim->getServerIp();
+      r_config.server_port = sim->getServerPort();
+      r_config.location.x = 300.f;
+      r_config.location.z = 50.f;
+      r_config.paint_targets = false;
+      r_config.send_radar_cube = true;
+      r_config.max_radar_returns = 45;
+      r_config.sbr.ray_division_y = 10.f;
+      r_config.sbr.ray_division_z = 10.f;
+      r_config.sbr.debug_scan = false;
+      r_config.sbr.debug_rescan = false;
+      r_config.sbr.debug_frustum = false;
+      r_config.listen_port = listen_port;
+      sensors.emplace_back(
+          std::make_shared<Sensor>(std::make_unique<RadarConfig>(r_config)));
+    } break;
+    case kSensorType::LIDAR: {
+      LidarConfig l_config;
+      l_config.server_ip = sim->getServerIp();
+      l_config.server_port = sim->getServerPort();
+      l_config.location.x = -10.f;
+      l_config.location.z = 190.f;
+      l_config.horizontal_resolution = 0.1f;
+      l_config.n_lasers = 16;
+      l_config.listen_port = listen_port;
+      sensors.emplace_back(
+          std::make_shared<Sensor>(std::make_unique<LidarConfig>(l_config)));
+    } break;
+    default:
+      std::cerr << "DistributedServer::AddSensor: ERROR! Unknown sensor type: "
+                << sensor_type << " for server " << sim->getServerIp() << ":"
+                << sim->getServerPort() << std::endl;
+      return false;
+  };
+
+  // Actually configure the sensors and make sure it worked
+  for (auto& sensor : sensors) {
+    if (!sensor->configure()) {
+      std::cerr << "DistributedServer::AddSensor: ERROR! Unable to "
+                   "configure sensor "
+                << sensor->config->type << " on port "
+                << sensor->config->listen_port << " for server "
+                << sim->getServerIp() << ":" << sim->getServerPort()
+                << std::endl;
+      return false;
+    }
+  }
+  return true;
+}
+
+void DistributedServer::StateSensorCallback(DataFrame* frame) {
+  // Grab the state data and signal that its available
+  state_sensor_data_updated = true;
+  if (state_data) {
+    *state_data =
+        static_cast<BinaryStateFrame*>(frame)->state_buffer.BufferToJson();
+  }
+}
+
+bool DistributedServer::Sample(nlohmann::json* input_state_data) {
+  state_data = input_state_data;
+  switch (server_type) {
+    case kServerType::PRIMARY:
+      // For primaries, always wait for the state data to come back
+      sim->sampleAll(sensors);
+      while(!state_sensor_data_updated);
+      state_sensor_data_updated = false;
+      break;
+    case kServerType::REPLICA:
+      // Replicas just get a state update
+      sim->stateStepSampleAll(sensors, *state_data);
+      break;
+    default:
+      std::cerr << "DistributedServer::Sample: ERROR! Unknown server type: "
+                << server_type << std::endl;
+      return false;
+  }
+  return true;
+}

--- a/examples/cpp/distributed/distributed_server.h
+++ b/examples/cpp/distributed/distributed_server.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <vector>
+#include <set>
+
+#include "Configuration.h"
+#include "Sensor.h"
+#include "Simulator.h"
+#include "DataFrame.h"
+
+namespace distributed_server {
+
+/// Global static for this class so nobody has any ports that clash
+static std::set<int> kServerReservedPorts;
+
+/// Servers are either the primary controller or the replica runners
+enum kServerType {
+    PRIMARY = 0,
+    REPLICA
+};
+
+/// Available sensor types for distributed server testing
+enum kSensorType {
+    BINARY_STATE = 0,
+    STATE,
+    VIEWPORT,
+    RADAR,
+    LIDAR
+};
+
+/// The primary server needs a scenario file for closed loop mode
+static const Configuration kPrimaryConfig(
+    "examples/config/simulator_straightaway.json",
+    "examples/config/weather.json",
+    "examples/config/scenario_multi_vehicle_straightaway.json");
+/// The replica servers just need to be forced into replay mode
+static const Configuration kReplicaConfig(
+    "examples/config/simulator_straightaway_replay.json",
+    "examples/config/weather.json", 
+    "examples/config/scenario.json");
+
+/// @class A class for managing benchmarking on distributed servers
+class DistributedServer {
+public:
+ /// @brief Constructor
+ /// @param ip_address - The IP address to the server
+ /// @param port - The port number for server command communication
+ /// @param server_type - Either the primary or replica server
+ DistributedServer(const std::string& ip_address, const int& port,
+                   const kServerType& server_type);
+ /// @brief Configure the specified sensors for the server
+ /// @param sensor_types - A vector of kSensorTypes to run on this server
+ /// @return true if all sensors were successfully configured
+ bool Configure(const std::vector<kSensorType>& sensor_types);
+ /// @brief Sample the sensors on this server
+ /// @param state_data - If this is a primary server this is populated with the 
+ /// current state data from the primary server. If this is a replica then the 
+ /// state data will be sent to server for update.
+ /// return true if the sampling was successful
+ bool Sample(nlohmann::json* state_data);
+
+private:
+ /// @brief The callback that will handle incoming state data for 
+ /// primary servers.
+ /// @param frame - The incoming state data frame
+ void StateSensorCallback(DataFrame* frame);
+ /// @brief Handle adding a predefined sensor to the server
+ /// @param sensor_type - The sensor to add
+ bool AddSensor(kSensorType sensor_type);
+
+ /// The array of sensors that is configured for this server
+ std::vector<std::shared_ptr<Sensor>> sensors;
+ /// A pointer to the server object
+ Simulator* sim = nullptr;
+ /// The current type of server
+ kServerType server_type;
+ /// Flag to communicate if state data has been received or not
+ bool state_sensor_data_updated = false;
+ /// The pointer to the current set of state data 
+ nlohmann::json* state_data;
+};
+}

--- a/monodrive/core/src/DataFrame.cpp
+++ b/monodrive/core/src/DataFrame.cpp
@@ -125,6 +125,10 @@ ByteBuffer StateFrame::write() const {
 	return buffer;
 }
 
+void BinaryStateFrame::parse(ByteBuffer& buffer){
+    state_buffer = buffer;
+}
+
 void CollisionFrame::parse(ByteBuffer& buffer){
     auto j = buffer.BufferToJson();
     json_get(j, "game_time", game_time);

--- a/monodrive/core/src/DataFrame.h
+++ b/monodrive/core/src/DataFrame.h
@@ -151,6 +151,13 @@ public:
 	int sample_count;
 };
 
+class MONODRIVECORE_API BinaryStateFrame : public StateFrame {
+public:
+    virtual void parse(ByteBuffer& buffer) override;
+    ByteBuffer state_buffer;
+};
+
+
 class MONODRIVECORE_API CollisionFrame : public DataFrame{
 public:
 	virtual void parse(ByteBuffer& buffer) override;

--- a/monodrive/core/src/sensor_config.h
+++ b/monodrive/core/src/sensor_config.h
@@ -54,8 +54,9 @@ public:
     std::vector<std::string> undesired_tags{};
     bool debug_drawing{false};
     bool include_obb{false};
+    bool send_binary_frame{false};
     virtual DataFrame* DataFrameFactory() override{
-        return new StateFrame;
+        return send_binary_frame ? new BinaryStateFrame : new StateFrame;
     }
     virtual nlohmann::json dump(){
         return *this;


### PR DESCRIPTION
This implements the first cut of the distributed architecture example for benchmarking the performance of various sensors on distributed servers. The example abstracts away a lot of the boiler plate server setup so that it is easier to quickly configure sensors in order to mix and match them with different server configurations.

The primary concept that enables this to work is having a single "primary" server that controls all the of the simulation physics and updates state information that can then be distributed to all of the "replica" servers. The example currently implements a primary server on local host and two replica servers that have RADAR and LiDAR configured. 

To run the example, just change the IP addresses in the `distributed.cpp` to match a similar setup.