### PR TITLE
Multithreading distributed arch

### DIFF
--- a/examples/config/simulator_straightaway_replay.json
+++ b/examples/config/simulator_straightaway_replay.json
@@ -4,6 +4,7 @@
   "server_port": 8999,
   "client_ip": "127.0.0.1",
   "map": "Straightaway5k",
+  "simulation_mode": 2,
   "phys_materials": {
     "Aluminum": {
       "specular_exponent": 15.0,

--- a/examples/cpp/distributed/distributed.cpp
+++ b/examples/cpp/distributed/distributed.cpp
@@ -13,7 +13,10 @@
 
 namespace ds = distributed_server;
 
-nlohmann::json SHARED_STATE_DATA;
+// The shared state data object that the primary will populate and the replicas
+// will use
+std::string SHARED_STATE_DATA("");
+// A mutex to protect the read/write state of the SHARED_STATE_DATA
 std::mutex STATE_DATA_MUTEX;
 
 void PrimaryThread(std::shared_ptr<ds::DistributedServer> server) {
@@ -51,7 +54,7 @@ void ReplicaThread(
   uint64_t sample_time = 0;
   int frame_count = 0;
   mono::precise_stopwatch replica_stopwatch;
-  nlohmann::json local_state_data;
+  std::string local_state_data;
 
   std::cout << "Replica thread starting..." << std::endl;
   while (true) {
@@ -61,11 +64,19 @@ void ReplicaThread(
 
     {
       std::lock_guard<std::mutex> lock(STATE_DATA_MUTEX);
-      local_state_data = nlohmann::json(SHARED_STATE_DATA);
+      local_state_data = SHARED_STATE_DATA;
+      // If there has not been a state data update yet, then keep waiting
+      if (local_state_data == "") {
+        continue;
+      }
     }
 
     for (auto& server : servers) {
       server->Sample(&local_state_data, true);
+    }
+
+    for (auto& server : servers) {
+      while (server->IsSampling());
     }
 
     sample_time +=
@@ -91,29 +102,30 @@ int main(int argc, char** argv) {
       std::make_shared<ds::DistributedServer>("127.0.0.1", 8999,
                                               ds::kServerType::PRIMARY);
   std::vector<std::shared_ptr<ds::DistributedServer>> replica_servers = {
-      // std::make_shared<ds::DistributedServer>("192.168.2.3", 8999,
-      //                                         ds::kServerType::REPLICA),
-      // ds::DistributedServer("192.168.2.3", 9000, ds::kServerType::REPLICA)
+      std::make_shared<ds::DistributedServer>("192.168.2.3", 8999,
+                                              ds::kServerType::REPLICA),
+      std::make_shared<ds::DistributedServer>("192.168.2.3", 9000,
+                                              ds::kServerType::REPLICA)
   };
 
   // Configure the senors for each server
   if (!primary_server->Configure(
           {ds::kSensorType::VIEWPORT, ds::kSensorType::BINARY_STATE}) 
-      //     ||
-      // !replica_servers[0]->Configure(
-      //     {ds::kSensorType::VIEWPORT, ds::kSensorType::RADAR}) 
-      //     ||
-      // !replica_servers[0].Configure(
-      //     {ds::kSensorType::VIEWPORT, ds::kSensorType::LIDAR})
+          ||
+      !replica_servers[0]->Configure(
+          {ds::kSensorType::VIEWPORT, ds::kSensorType::RADAR})
+          ||
+      !replica_servers[1]->Configure(
+          {ds::kSensorType::VIEWPORT, ds::kSensorType::LIDAR})
           ) {
     return -1;
   }
 
   // Bench marking stuff
   std::thread primary_thread(PrimaryThread, primary_server);
-  //std::thread replica_thread(ReplicaThread, replica_servers);
+  std::thread replica_thread(ReplicaThread, replica_servers);
 
   primary_thread.join();
-  //replica_thread.join();
+  replica_thread.join();
   return 0;
 }

--- a/examples/cpp/distributed/distributed.cpp
+++ b/examples/cpp/distributed/distributed.cpp
@@ -13,63 +13,107 @@
 
 namespace ds = distributed_server;
 
+nlohmann::json SHARED_STATE_DATA;
+std::mutex STATE_DATA_MUTEX;
+
+void PrimaryThread(std::shared_ptr<ds::DistributedServer> server) {
+  uint64_t control_time = 0;
+  int frame_count = 0;
+  mono::precise_stopwatch primary_stopwatch;
+
+  std::cout << "Primary thread starting..." << std::endl;
+  while (true) {
+    auto control_start_time =
+        primary_stopwatch.elapsed_time<uint64_t, std::chrono::microseconds>();
+    {
+      std::lock_guard<std::mutex> lock(STATE_DATA_MUTEX);
+      server->Sample(&SHARED_STATE_DATA);
+    }
+
+    control_time +=
+        primary_stopwatch.elapsed_time<uint64_t, std::chrono::microseconds>() -
+        control_start_time;
+
+    if ((++frame_count) % 100 == 0) {
+      std::cout << "=== Control Avg: " << (control_time / frame_count) / 1e6
+                << std::endl;
+      std::cout << "FPS: " << frame_count / (control_time / 1e6) << std::endl;
+      frame_count = 0;
+      control_time = 0;
+    }
+  }
+
+  std::cout << "Primary thread ending..." << std::endl;
+}
+
+void ReplicaThread(
+    std::vector<std::shared_ptr<ds::DistributedServer>> servers) {
+  uint64_t sample_time = 0;
+  int frame_count = 0;
+  mono::precise_stopwatch replica_stopwatch;
+  nlohmann::json local_state_data;
+
+  std::cout << "Replica thread starting..." << std::endl;
+  while (true) {
+    // Cue the replicas and time them
+    auto sample_start_time =
+        replica_stopwatch.elapsed_time<uint64_t, std::chrono::microseconds>();
+
+    {
+      std::lock_guard<std::mutex> lock(STATE_DATA_MUTEX);
+      local_state_data = nlohmann::json(SHARED_STATE_DATA);
+    }
+
+    for (auto& server : servers) {
+      server->Sample(&local_state_data, true);
+    }
+
+    sample_time +=
+        replica_stopwatch.elapsed_time<uint64_t, std::chrono::microseconds>() -
+        sample_start_time;
+
+    // Spit out FPS data every 10 frames
+    if ((++frame_count) % 30 == 0) {
+      std::cout << "=== Sample Avg: " << (sample_time / frame_count) / 1e6
+                << std::endl;
+      std::cout << "FPS: " << frame_count / ((sample_time) / 1e6)
+                << std::endl;
+      frame_count = 0;
+      sample_time = 0;
+    }
+  }
+  std::cout << "Replica thread ending..." << std::endl;
+}
+
 int main(int argc, char** argv) {
   // Set up all the server
-  ds::DistributedServer primary_server =
-      ds::DistributedServer("127.0.0.1", 8999, ds::kServerType::PRIMARY);
-  std::vector<ds::DistributedServer> replica_servers = {
-      ds::DistributedServer("192.168.2.3", 8999, ds::kServerType::REPLICA),
-      ds::DistributedServer("192.168.2.3", 9000, ds::kServerType::REPLICA)};
+  auto primary_server =
+      std::make_shared<ds::DistributedServer>("127.0.0.1", 8999,
+                                              ds::kServerType::PRIMARY);
+  std::vector<std::shared_ptr<ds::DistributedServer>> replica_servers = {
+      // std::make_shared<ds::DistributedServer>("192.168.2.3", 8999,
+      //                                         ds::kServerType::REPLICA),
+      // ds::DistributedServer("192.168.2.3", 9000, ds::kServerType::REPLICA)
+  };
 
   // Configure the senors for each server
-  if (!primary_server.Configure(
-          {ds::kSensorType::VIEWPORT, ds::kSensorType::BINARY_STATE}) ||
-      !replica_servers[0].Configure(
-          {ds::kSensorType::VIEWPORT, ds::kSensorType::RADAR}) ||
-      !replica_servers[1].Configure(
-          {ds::kSensorType::VIEWPORT, ds::kSensorType::LIDAR})) {
+  if (!primary_server->Configure(
+          {ds::kSensorType::VIEWPORT, ds::kSensorType::BINARY_STATE}) 
+      //     ||
+      // !replica_servers[0]->Configure(
+      //     {ds::kSensorType::VIEWPORT, ds::kSensorType::RADAR}) 
+      //     ||
+      // !replica_servers[0].Configure(
+      //     {ds::kSensorType::VIEWPORT, ds::kSensorType::LIDAR})
+          ) {
     return -1;
   }
 
   // Bench marking stuff
-  int frame_count = 0;
-  uint64_t control_time = 0;
-  uint64_t sample_time = 0;
-  mono::precise_stopwatch stopwatch;
-  // Shared data between servers
-  nlohmann::json state_data;
-  while (true) {
-    // Cue the primary and time it
-    auto control_start_time =
-        stopwatch.elapsed_time<uint64_t, std::chrono::microseconds>();
-    primary_server.Sample(&state_data);
-    control_time +=
-        stopwatch.elapsed_time<uint64_t, std::chrono::microseconds>() -
-        control_start_time;
+  std::thread primary_thread(PrimaryThread, primary_server);
+  //std::thread replica_thread(ReplicaThread, replica_servers);
 
-    // Cue the replicas and time them
-    auto sample_start_time =
-        stopwatch.elapsed_time<uint64_t, std::chrono::microseconds>();
-    for (auto server : replica_servers) {
-      server.Sample(&state_data);
-    }
-    sample_time +=
-        stopwatch.elapsed_time<uint64_t, std::chrono::microseconds>() -
-        sample_start_time;
-
-    // Spit out FPS data every 10 frames
-    if ((++frame_count) % 10 == 0) {
-      std::cout << "Control Avg: " << (control_time / frame_count) / 1e6
-                << std::endl;
-      std::cout << "Sample Avg: " << (sample_time / frame_count) / 1e6
-                << std::endl;
-      std::cout << "FPS: " << frame_count / ((control_time + sample_time) / 1e6)
-                << std::endl;
-      frame_count = 0;
-      control_time = 0;
-      sample_time = 0;
-    }
-  }
-
+  primary_thread.join();
+  //replica_thread.join();
   return 0;
 }

--- a/examples/cpp/distributed/distributed_server.cpp
+++ b/examples/cpp/distributed/distributed_server.cpp
@@ -15,6 +15,22 @@ DistributedServer::DistributedServer(const std::string& ip_address,
 
   // All server ports are technically reserved as well
   kServerReservedPorts.insert(port);
+
+  sample_thread = std::thread(&DistributedServer::SampleThread, this);
+}
+
+DistributedServer::DistributedServer(const DistributedServer& rhs) {
+  server_type = rhs.server_type;
+  sim = rhs.sim;
+  sensors = rhs.sensors;
+}
+
+DistributedServer::~DistributedServer() {
+  connected = false;
+  sample_trigger.notify_all();
+  if (sample_thread.joinable()) {
+    sample_thread.join();
+  }
 }
 
 bool DistributedServer::Configure(const std::vector<kSensorType>& sensor_types){
@@ -96,7 +112,7 @@ bool DistributedServer::AddSensor(kSensorType sensor_type) {
       l_config.server_port = sim->getServerPort();
       l_config.location.x = -10.f;
       l_config.location.z = 190.f;
-      l_config.horizontal_resolution = 0.1f;
+      l_config.horizontal_resolution = 0.4f;
       l_config.n_lasers = 16;
       l_config.listen_port = listen_port;
       sensors.emplace_back(
@@ -133,23 +149,38 @@ void DistributedServer::StateSensorCallback(DataFrame* frame) {
   }
 }
 
-bool DistributedServer::Sample(nlohmann::json* input_state_data) {
+bool DistributedServer::Sample(nlohmann::json* input_state_data, bool async) {
   state_data = input_state_data;
-  switch (server_type) {
-    case kServerType::PRIMARY:
-      // For primaries, always wait for the state data to come back
-      sim->sampleAll(sensors);
-      while(!state_sensor_data_updated);
-      state_sensor_data_updated = false;
-      break;
-    case kServerType::REPLICA:
-      // Replicas just get a state update
-      sim->stateStepSampleAll(sensors, *state_data);
-      break;
-    default:
-      std::cerr << "DistributedServer::Sample: ERROR! Unknown server type: "
-                << server_type << std::endl;
-      return false;
+  std::unique_lock<std::mutex> lk(sample_mutex);
+  sample_complete = false;
+  sample_trigger.notify_all();
+  if (!async) {
+    while(!sample_complete);
   }
   return true;
+}
+
+
+void DistributedServer::SampleThread() {
+  while (connected) {
+    std::unique_lock<std::mutex> lk(sample_mutex);
+    sample_trigger.wait(lk, [=]{return !sample_complete;});
+    switch (server_type) {
+      case kServerType::PRIMARY:
+        // For primaries, always wait for the state data to come back
+        sim->sampleAll(sensors);
+        while (!state_sensor_data_updated);
+        state_sensor_data_updated = false;
+        break;
+      case kServerType::REPLICA:
+        // Replicas just get a state update
+        sim->stateStepSampleAll(sensors, *state_data);
+        break;
+      default:
+        std::cerr << "DistributedServer::Sample: ERROR! Unknown server type: "
+                  << server_type << std::endl;
+    }
+    lk.unlock();
+    sample_complete = true;
+  }
 }

--- a/examples/cpp/distributed/distributed_server.h
+++ b/examples/cpp/distributed/distributed_server.h
@@ -71,17 +71,20 @@ public:
  /// return true if the sampling was successful
  /// @param async - If true, then this call will be non-blocking. Default is
  /// false.
- bool Sample(nlohmann::json* state_data, bool async=false);
+ bool Sample(std::string* state_data, bool async=false);
+ /// @brief Determine if this server is still sampling sensors
+ /// @return true if a sample is still in progress
+ bool IsSampling();
 
 private:
- /// @brief The callback that will handle incoming state data for 
+ /// @brief The callback that will handle incoming state data for
  /// primary servers.
  /// @param frame - The incoming state data frame
  void StateSensorCallback(DataFrame* frame);
  /// @brief Handle adding a predefined sensor to the server
  /// @param sensor_type - The sensor to add
  bool AddSensor(kSensorType sensor_type);
-
+ /// @brief The main worker thread for triggering sensor samples
  void SampleThread();
 
  /// The array of sensors that is configured for this server
@@ -92,18 +95,21 @@ private:
  kServerType server_type;
  /// Flag to communicate if state data has been received or not
  bool state_sensor_data_updated = false;
- /// The pointer to the current set of state data 
- nlohmann::json* state_data = nullptr;
+ /// The pointer to the current set of state data
+ std::string* state_data_string = nullptr;
  /// Condition variable to signal that a sample should occur
  std::condition_variable sample_trigger;
  /// Mutex for the sample thread's trigger
  std::mutex sample_mutex;
+ /// True if the server is ready for another sample
+ bool ready_to_sample{false};
+ /// True if the current sample has been completed
  bool sample_complete{false};
  /// Mutex to wait for a non-async sample to complete
  std::mutex sample_complete_mutex;
  /// Thread that performs a sample on this server
  std::thread sample_thread;
  /// Condition that we are currently connected to a server
- bool connected = true;
-};
+ bool connected{true};
+ };
 }

--- a/monodrive/core/src/Simulator.cpp
+++ b/monodrive/core/src/Simulator.cpp
@@ -194,11 +194,40 @@ bool Simulator::step(int stepIndex, int numSteps)
 	return sendCommand(message);
 }
 
-bool Simulator::stateStepSampleAll(std::vector<std::shared_ptr<Sensor>>& sensors, const nlohmann::json& state)
+bool Simulator::sampleInProgress(std::vector<std::shared_ptr<Sensor>>& sensors){
+  // are sensors done sampling?
+  bool samplingInProgress = false;
+  // is simulator done stepping?
+  if (true && lastSendCommand.load(std::memory_order::memory_order_relaxed)) {
+    for (auto& sensor : sensors) {
+      if (sensor->sampleInProgress.load(
+              std::memory_order::memory_order_relaxed)) {
+        samplingInProgress = true;
+        break;
+      }
+    }
+  }
+  return samplingInProgress;
+}
+
+bool Simulator::stateStepAll(std::vector<std::shared_ptr<Sensor>>& sensors, const nlohmann::json& state)
 {
 	ApiMessage message(333, REPLAY_StateStepSimulationCommand_ID, true, state);
 	for(auto& sensor : sensors)
     {
+		sensor->sampleInProgress.store(true, std::memory_order::memory_order_relaxed);
+	}
+	lastSendCommand = sendCommand(message);
+
+	return lastSendCommand;
+}
+
+
+bool Simulator::stateStepSampleAll(std::vector<std::shared_ptr<Sensor>>& sensors, const nlohmann::json& state)
+{
+	ApiMessage message(333, REPLAY_StateStepSimulationCommand_ID, true, state);
+	for(auto& sensor : sensors)
+   {
 		sensor->sampleInProgress.store(true, std::memory_order::memory_order_relaxed);
 	}
 	bool success = sendCommand(message);

--- a/monodrive/core/src/Simulator.h
+++ b/monodrive/core/src/Simulator.h
@@ -41,6 +41,9 @@ public:
 	bool stateStepSampleAll(std::vector<std::shared_ptr<Sensor>>& sensors, const nlohmann::json& state);
 	void stepSampleAll(std::vector<std::shared_ptr<Sensor>>& sensors, int stepIndex, int numSteps);
 
+	bool stateStepAll(std::vector<std::shared_ptr<Sensor>>& sensors, const nlohmann::json& state);
+	bool sampleInProgress(std::vector<std::shared_ptr<Sensor>>& sensors);
+
 	// triggers every sensor on the server to send it's data frame
 	// the sensors in the list will go into a read state
 	// this should only be called when the sensors in the list count for all the sensors on the server
@@ -66,4 +69,5 @@ private:
 	Configuration config;
 	std::string serverIp;
 	short serverPort;
+	std::atomic<bool> lastSendCommand{false};
 };


### PR DESCRIPTION
Updates to the distributed architecture to provide multi-threading support.

This implements two threads that do work for the primary and replica servers independently. Additionally, the `DistributedServer` class now implements an optionally non-blocking call to sample that allows for a "broadcast" of the state data.

Some of the core code was changed to support functionality necessary for splitting the send state and sample sensors checks. This should improve the performance overall and enable a distributed architecture to quickly distribute the current state to multiple instances and then wait for the sensor returns independently.

I'm going to go ahead and merge this into the distributed architecture branch and append this text to the PR of that branch into the development. #74 