### PR TITLE
Add CMake install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Note: Extract or install these libraries to **C:/local** for cmake can find them
 - [Boost](https://sourceforge.net/projects/boost/files/boost-binaries/1.73.0/boost_1_73_0-msvc-14.2-64.exe/download) 
   - Add `C:\local\boost_1_73_0\lib64-msvc-14.2` to your PATH variable
   - Create the `BOOST_ROOT` environment variable and set it to`C:\local\boost_1_73_0\` 
+- [CMake](https://cmake.org/download/) 
+  - When installing, make sure to choose the option to CMake to your Windows Path variable.
 
 To build the examples the following are required:
 - [OpenCV](https://github.com/opencv/opencv/releases/download/4.3.0/opencv-4.3.0-vc14_vc15.exe) Extract to `C:\local\opencv` and add `C:\local\opencv\build\x64\vc15\bin` to your PATH environment variable.


### PR DESCRIPTION
If CMake is installed with Visual Studio Code, the older version can cause issues when compiling. We need to explicitly install CMake to get everything working with VS Code and Visual Studio 2019. 

This was brought up as an issue when a customer had both Visual Studio 2017 and 2019 installed on the same machine. The version of CMake would continually pick up the wrong kit (2017) and when the kit was explicitly set it would say that VS 2019 was not supported.