### PR TITLE
Fisheye vignette

### DIFF
--- a/examples/cpp/dev/fisheye_camera.cpp
+++ b/examples/cpp/dev/fisheye_camera.cpp
@@ -16,8 +16,8 @@
 #include "opencv2/highgui.hpp"
 #include "opencv2/imgproc.hpp"
 
-#define IMG_WIDTH 1280
-#define IMG_HEIGHT 1280
+#define IMG_WIDTH 1920
+#define IMG_HEIGHT 1080
 
 int main(int argc, char** argv)
 {
@@ -40,16 +40,15 @@ int main(int argc, char** argv)
     // Configure the sensors we wish to use
     std::vector<std::shared_ptr<Sensor>> sensors;
 
-    FisheyeCameraConfig fc_config;
+    FisheyeCameraConfig fc_config(Resolution(IMG_WIDTH, IMG_HEIGHT));
     fc_config.server_ip = sim0.getServerIp();
     fc_config.server_port = sim0.getServerPort();
     fc_config.listen_port = 8100;
     fc_config.location.z = 225;
-    fc_config.resolution = Resolution(IMG_WIDTH,IMG_WIDTH);
     fc_config.fov = 180.f;
     fc_config.rotation.yaw = -90.f;
-    // face_size should be smaller than the largest resolution
-    // increasing face_size improves image quality and vice versa with diminishing returns wrt to the image resolution
+    /// face_size should be smaller than the largest resolution
+    /// increasing face_size improves image quality and vice versa with diminishing returns wrt to the image resolution
     fc_config.face_size = 1024;
     sensors.push_back(std::make_shared<Sensor>(std::make_unique<FisheyeCameraConfig>(fc_config)));
 

--- a/examples/cpp/dev/fisheye_camera.cpp
+++ b/examples/cpp/dev/fisheye_camera.cpp
@@ -47,8 +47,16 @@ int main(int argc, char** argv)
     fc_config.location.z = 225;
     fc_config.fov = 180.f;
     fc_config.rotation.yaw = -90.f;
-    /// face_size should be smaller than the largest resolution
-    /// increasing face_size improves image quality and vice versa with diminishing returns wrt to the image resolution
+    // before the hard mechanical vignette at what point should the fade start normalized with respect to the diameter of the fisheye
+    fc_config.vignette_radius_start = 0.95f;
+    // in the transition to black at the start of the mechanical vignette start with this value of black before the linear fade
+    fc_config.vignette_bias = 0.5f;
+    // for a bounded fisheye set the pixel diameter to the smallest axis, or to the measured real pixel diameter limit from the image
+    // for a diagonal bounded fisheye set the pixel diameter to the hypotenuse of the image
+    // for a fisheye that is greater than the image plane use the value from your model
+    fc_config.fisheye_pixel_diameter = std::min(fc_config.resolution.x, fc_config.resolution.y);
+    // face_size should be smaller than the largest resolution
+    // increasing face_size improves image quality and vice versa with diminishing returns wrt to the image resolution
     fc_config.face_size = 1024;
     sensors.push_back(std::make_shared<Sensor>(std::make_unique<FisheyeCameraConfig>(fc_config)));
 

--- a/monodrive/core/src/sensor_config.h
+++ b/monodrive/core/src/sensor_config.h
@@ -246,7 +246,17 @@ public:
     {
         type = "FisheyeCamera";
         fov = 180.f;
+        fisheye_pixel_diameter = std::min(resolution.x, resolution.y);
     }
+    FisheyeCameraConfig(Resolution res) : Camera360Config(){
+        type = "FisheyeCamera";
+        fov = 180.f;
+        resolution = res;
+        fisheye_pixel_diameter = std::min(resolution.x, resolution.y);
+    }
+    float fisheye_pixel_diameter;
+    float vignette_radius_start = 0.95f;
+    float vignette_bias = 0.5f;
 };
 
 class SemanticCameraConfig : public CameraConfig

--- a/monodrive/core/src/sensor_config.h
+++ b/monodrive/core/src/sensor_config.h
@@ -157,7 +157,7 @@ public:
     }
     double fc{40000.0};
     double pwm_factor{2.5};
-    float period{60.0 / 1000.0f};
+    float period{60.0f / 1000.0f};
     int max_ultrasonic_returns{93};
     bool send_processed_data{true};
     struct SBR
@@ -254,9 +254,12 @@ public:
         resolution = res;
         fisheye_pixel_diameter = std::min(resolution.x, resolution.y);
     }
-    float fisheye_pixel_diameter;
+    int fisheye_pixel_diameter;
     float vignette_radius_start = 0.95f;
     float vignette_bias = 0.5f;
+    virtual nlohmann::json dump() {
+        return *this;
+    }
 };
 
 class SemanticCameraConfig : public CameraConfig
@@ -498,6 +501,13 @@ void inline to_json(nlohmann::json& j, const Camera360Config& config){
     j["face_size"] = config.face_size;
 }
 
+void inline to_json(nlohmann::json& j, const FisheyeCameraConfig& config){
+    j = static_cast<Camera360Config>(config);
+    j["fisheye_pixel_diameter"] = config.fisheye_pixel_diameter;
+    j["vignette_bias"] = config.vignette_bias;
+    j["vignette_radius_start"] = config.vignette_radius_start;
+}
+
 void inline to_json(nlohmann::json& j, const CameraConfig& config)
 {
     j = static_cast<SensorBaseConfig>(config);
@@ -540,6 +550,15 @@ void inline from_json(const nlohmann::json& j, Camera360Config& config)
     from_json(j, *base);
 
     json_get(j, "face_size", config.face_size);
+}
+
+void inline from_json(const nlohmann::json& j, FisheyeCameraConfig& config){
+    Camera360Config* base = static_cast<Camera360Config*>(&config);
+    from_json(j, *base);
+
+    json_get(j, "fisheye_pixel_diameter", config.fisheye_pixel_diameter);
+    json_get(j, "vignette_bias", config.vignette_bias);
+    json_get(j, "vignette_radius_start", config.vignette_radius_start);
 }
 
 void inline to_json(nlohmann::json& j, const ViewportCameraConfig& config)


### PR DESCRIPTION
Updates the fisheye shader to include mechanical vignetting (ie the image is circular and everything beyond the radius is black). Also there is some control with respect to the fade to black at the radius of the circle which can be set by user in client.

The user can still set a diameter that is the hypotenuse in which case the vignette will not be visible except at corners. This is a common configuration. diameter = FOV

I believe all vignette radius configurations are now configurable for this shader.

Example includes comments for what these parameters do.