### PR TITLE
Allows multiple connections from client to server and adds callback example for control in ROS distributed example

### DIFF
--- a/examples/cpp/dev/CMakeLists.txt
+++ b/examples/cpp/dev/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(autopilot_control autopilot_control.cpp)
 add_executable(camera_360 camera_360.cpp)
 add_executable(fisheye_camera fisheye_camera.cpp)
 add_executable(sensors_from_json sensors_from_json.cpp)
+add_executable(multi_connection multi_connection.cpp)
 
 # link monodrive client
 target_link_libraries(camera_sensor monodrive)
@@ -58,6 +59,7 @@ target_link_libraries(autopilot_control monodrive)
 target_link_libraries(camera_360 monodrive)
 target_link_libraries(fisheye_camera monodrive)
 target_link_libraries(sensors_from_json monodrive)
+target_link_libraries(multi_connection monodrive)
 
 # copy monodrive dll to runtime directory
 if(MSVC)
@@ -93,6 +95,7 @@ if(MSVC)
   add_dependencies(camera_360 monodrive_lib_copy_dev)
   add_dependencies(fisheye_camera monodrive_lib_copy_dev)
   add_dependencies(sensors_from_json monodrive_lib_copy_dev)
+  add_dependencies(multi_connection monodrive_lib_copy_dev)
 endif(MSVC)
 
 # eigen
@@ -149,6 +152,10 @@ target_link_libraries(fisheye_camera ${OpenCV_LIBRARIES})
 target_include_directories(sensors_from_json PUBLIC ${OpenCV_INCLUDE_DIRS})
 link_libraries(sensors_from_json ${OpenCV_LIBRARIES})
 target_link_libraries(sensors_from_json ${OpenCV_LIBRARIES})
+
+target_include_directories(multi_connection PUBLIC ${OpenCV_INCLUDE_DIRS})
+link_libraries(multi_connection ${OpenCV_LIBRARIES})
+target_link_libraries(multi_connection ${OpenCV_LIBRARIES})
 
 # filesystem
 target_link_libraries(config_export -lstdc++fs)

--- a/examples/cpp/dev/multi_connection.cpp
+++ b/examples/cpp/dev/multi_connection.cpp
@@ -111,6 +111,8 @@ int main(int argc, char** argv)
             sim0.sampleAll(sensors);
         }
     });
+    // create a separate connection for the control command so that it can be called asynchronosouly without contention
+    // on the command channel
     auto egoControlServer = std::make_unique<Simulator>(sim0.getServerIp(), sim0.getServerPort());
     egoControlServer->connect();
     std::thread t2([egoControlServer_ = std::move(egoControlServer)](){

--- a/examples/cpp/dev/multi_connection.cpp
+++ b/examples/cpp/dev/multi_connection.cpp
@@ -1,0 +1,126 @@
+#include <iostream>		  // std::cout
+#include <chrono>		  // std::chrono	
+#include <thread>         // std::thread
+#include <memory>
+#include <vector>
+#include <future>
+
+//monoDrive Includes
+#include "Simulator.h"
+#include "Configuration.h"  // holder for sensor, simulator, scenario, weather, and vehicle configurations
+#include "Sensor.h"
+#include "sensor_config.h"
+#include "Stopwatch.h"
+
+#include "opencv2/core.hpp"
+#include "opencv2/core/utility.hpp"
+#include "opencv2/highgui.hpp"
+#include "opencv2/imgproc.hpp"
+
+// #define IMG_WIDTH 4096
+// #define IMG_HEIGHT 2160
+
+#define IMG_WIDTH 1920
+#define IMG_HEIGHT 1080
+
+
+int main(int argc, char** argv)
+{
+    //Single Simulator Example
+    std::string server0_ip = "127.0.0.1";
+    int server_port = 8999;   // This has to be 8999 this simulator is listening for connections on this port;
+
+    //Read JSON files in cpp_client/config directory
+    Configuration config(
+        "examples/config/simulator_straightaway.json",
+        "examples/config/weather.json",
+        "examples/config/scenario_multi_vehicle_straightaway.json"
+    );
+    Simulator& sim0 = Simulator::getInstance(config, server0_ip, server_port);
+
+    config.weather["set_profile"] = "MidRainyNoon";
+
+    // Configure simulator
+    if(!sim0.configure()){
+        return -1;
+    }
+
+    // Configure the sensors we wish to use
+    std::vector<std::shared_ptr<Sensor>> sensors;
+
+    CameraConfig fc_config;
+    fc_config.server_ip = sim0.getServerIp();
+    fc_config.server_port = sim0.getServerPort();
+    fc_config.listen_port = 8100;// + i;
+    fc_config.location.z = 225;
+    fc_config.rotation.pitch = -5;
+    // Uncomment to receive grayscale images
+    // fc_config.channels = "gray";
+    fc_config.resolution = Resolution(IMG_WIDTH,IMG_HEIGHT);
+    fc_config.annotation.include_annotation = true;
+    fc_config.annotation.desired_tags = {"traffic_sign", "vehicle"};
+    sensors.push_back(std::make_shared<Sensor>(std::make_unique<CameraConfig>(fc_config)));
+
+    ViewportCameraConfig vp_config;
+    vp_config.server_ip = sim0.getServerIp();
+    vp_config.server_port = sim0.getServerPort();
+    vp_config.location.z = 200;
+    vp_config.resolution = Resolution(256,256);
+    Sensor(std::make_unique<ViewportCameraConfig>(vp_config)).configure();
+
+    // Send configurations to the simulator
+    std::cout<<"***********ALL SENSOR's CONFIGS*******"<<std::endl;
+    for (auto& sensor : sensors)
+    {
+        sensor->configure();
+    }
+
+    //Get number of steps in scenario and start timer
+    mono::precise_stopwatch stopwatch;
+
+    sensors[0]->sampleCallback = [](DataFrame *frame) {
+        auto camFrame = static_cast<CameraFrame *>(frame);
+        auto imFrame = camFrame->imageFrame;
+        cv::Mat img;
+        if (imFrame->channels == 4)
+        {
+            img = cv::Mat(imFrame->resolution.y, imFrame->resolution.x, CV_8UC4,
+                          imFrame->pixels);
+        }
+        else
+        {
+            img = cv::Mat(imFrame->resolution.y, imFrame->resolution.x, CV_8UC1,
+                          imFrame->pixels);
+            cv::cvtColor(img, img, cv::COLOR_GRAY2BGRA);
+        }
+        for (auto &annotation : camFrame->annotationFrame->annotations)
+        {
+            for (auto &bbox : annotation.second.bounding_boxes_2d)
+                cv::rectangle(img, cv::Point(int(bbox.xmin), int(bbox.ymin)),
+                              cv::Point(int(bbox.xmax), int(bbox.ymax)),
+                              cv::Scalar(0, 0, 255));
+        }
+        cv::imshow("monoDrive", img);
+        cv::waitKey(1);
+    };
+
+    std::cout << "Sampling sensor loop" << std::endl;
+    std::thread t1([&sim0, &sensors](){
+        while(true)
+        {
+            sim0.sampleAll(sensors);
+        }
+    });
+    auto egoControlServer = std::make_unique<Simulator>(sim0.getServerIp(), sim0.getServerPort());
+    egoControlServer->connect();
+    std::thread t2([egoControlServer_ = std::move(egoControlServer)](){
+        while(true)
+        {
+            egoControlServer_->sendControl(0.2f, 0.1f, 0.f, 1);
+        }
+    });
+    t1.join();
+    t2.join();
+
+    return 0;
+}

--- a/examples/cpp/distributed/distributed.cpp
+++ b/examples/cpp/distributed/distributed.cpp
@@ -32,6 +32,7 @@ void PrimaryThread(std::shared_ptr<PrimaryDistributedServer> server, Event* repl
   mono::precise_stopwatch primary_stopwatch;
 
   std::cout << "Primary thread starting..." << std::endl;
+  auto EgoControlServer = std::make_unique<Simulator>(server->GetSimulator()->getServerIp(), server->GetSimulator()->getServerPort());
   while (RUN_EXAMPLE) {
     auto control_start_time =
         primary_stopwatch.elapsed_time<uint64_t, std::chrono::microseconds>();
@@ -47,7 +48,7 @@ void PrimaryThread(std::shared_ptr<PrimaryDistributedServer> server, Event* repl
     ego_control_config.right_amount = 0.0f;
     ego_control_config.brake_amount = 0.0f;
     ego_control_config.drive_mode = 1;
-    server->sendCommandAsync(ego_control_config.message());
+    EgoControlServer->sendCommandAsync(ego_control_config.message());
 
     control_time +=
         primary_stopwatch.elapsed_time<uint64_t, std::chrono::microseconds>() -

--- a/examples/cpp/distributed/distributed.cpp
+++ b/examples/cpp/distributed/distributed.cpp
@@ -32,7 +32,8 @@ void PrimaryThread(std::shared_ptr<PrimaryDistributedServer> server, Event* repl
   mono::precise_stopwatch primary_stopwatch;
 
   std::cout << "Primary thread starting..." << std::endl;
-  auto EgoControlServer = std::make_unique<Simulator>(server->GetSimulator()->getServerIp(), server->GetSimulator()->getServerPort());
+  auto egoControlServer = std::make_unique<Simulator>(server->GetSimulator()->getServerIp(), server->GetSimulator()->getServerPort());
+  egoControlServer->connect();
   while (RUN_EXAMPLE) {
     auto control_start_time =
         primary_stopwatch.elapsed_time<uint64_t, std::chrono::microseconds>();
@@ -48,7 +49,7 @@ void PrimaryThread(std::shared_ptr<PrimaryDistributedServer> server, Event* repl
     ego_control_config.right_amount = 0.0f;
     ego_control_config.brake_amount = 0.0f;
     ego_control_config.drive_mode = 1;
-    EgoControlServer->sendCommandAsync(ego_control_config.message());
+    egoControlServer->sendCommandAsync(ego_control_config.message());
 
     control_time +=
         primary_stopwatch.elapsed_time<uint64_t, std::chrono::microseconds>() -

--- a/examples/cpp/distributed/distributed.cpp
+++ b/examples/cpp/distributed/distributed.cpp
@@ -32,7 +32,9 @@ void PrimaryThread(std::shared_ptr<PrimaryDistributedServer> server, Event* repl
   mono::precise_stopwatch primary_stopwatch;
 
   std::cout << "Primary thread starting..." << std::endl;
-  auto egoControlServer = std::make_unique<Simulator>(server->GetSimulator()->getServerIp(), server->GetSimulator()->getServerPort());
+  // create a separate connection for the control command so that it can be called asynchronosouly without contention
+  // on the command channel
+  auto egoControlServer = std::make_unique<Simulator>(server->getSimulator()->getServerIp(), server->getSimulator()->getServerPort());
   egoControlServer->connect();
   while (RUN_EXAMPLE) {
     auto control_start_time =

--- a/examples/ros/src/distributed/src/distributed.cpp
+++ b/examples/ros/src/distributed/src/distributed.cpp
@@ -203,6 +203,17 @@ int main(int argc, char **argv)
     }
   }
 
+  auto egoControlServer = std::make_unique<Server>(primaryServer->GetSimulator()->getServerPort(), primaryServer->GetSimulator()->getServerIp());
+  ros::NodeHandle ego_control_node_handle;
+  ros::Subscriber ego_control_sub = ego_control_node_handle->subscribe("/your_controller_topic/vehicle_control", 1, [egoControlServer = std::move(egoControlServer)](const monodrive_msgs::VehicleControl &vehicle_control){
+    EgoControlConfig egoControl;
+    egoControl.forward_amount = vehicle_control.throttle;
+    egoControl.brake_amount = vehicle_control.brake;
+    egoControl.drive_mode = vehicle_control.drive_mode;
+    egoControl.right_amount = vehicle_control.steer;
+    egoControlServer->sendCommand(ApiMessage(777, EgoControl_ID, true, egoControl.dump()));
+  });
+
   // Configure the primary 
   if (!primaryServer->configure()){
     std::cerr << "Unable to configure primary server!" << std::endl;

--- a/examples/ros/src/distributed/src/distributed.cpp
+++ b/examples/ros/src/distributed/src/distributed.cpp
@@ -203,7 +203,9 @@ int main(int argc, char **argv)
     }
   }
 
-  auto egoControlServer = std::make_unique<Server>(primaryServer->GetSimulator()->getServerIp(), primaryServer->GetSimulator()->getServerPort());
+  // create a separate connection for the control command so that it can be called asynchronosouly without contention
+  // on the command channel
+  auto egoControlServer = std::make_unique<Server>(primaryServer->getSimulator()->getServerIp(), primaryServer->getSimulator()->getServerPort());
   egoControlServer->connect();
   ros::NodeHandle ego_control_node_handle;
   ros::Subscriber ego_control_sub = ego_control_node_handle->subscribe("/your_controller_topic/vehicle_control", 1, [egoControlServer = std::move(egoControlServer)](const monodrive_msgs::VehicleControl &vehicle_control){

--- a/examples/ros/src/distributed/src/distributed.cpp
+++ b/examples/ros/src/distributed/src/distributed.cpp
@@ -203,7 +203,8 @@ int main(int argc, char **argv)
     }
   }
 
-  auto egoControlServer = std::make_unique<Server>(primaryServer->GetSimulator()->getServerPort(), primaryServer->GetSimulator()->getServerIp());
+  auto egoControlServer = std::make_unique<Server>(primaryServer->GetSimulator()->getServerIp(), primaryServer->GetSimulator()->getServerPort());
+  egoControlServer->connect();
   ros::NodeHandle ego_control_node_handle;
   ros::Subscriber ego_control_sub = ego_control_node_handle->subscribe("/your_controller_topic/vehicle_control", 1, [egoControlServer = std::move(egoControlServer)](const monodrive_msgs::VehicleControl &vehicle_control){
     EgoControlConfig egoControl;

--- a/monodrive/core/src/DistributedServer.h
+++ b/monodrive/core/src/DistributedServer.h
@@ -113,7 +113,9 @@ public:
     virtual bool sendCommand(ApiMessage message, nlohmann::json* response=nullptr);
     /// @brief Send command to server and return immediately
     virtual bool sendCommandAsync(ApiMessage message, nlohmann::json* response=nullptr);
-    Simulator* GetSimulator();
+    inline Simulator* getSimulator(){
+        return sim; 
+    }
 
 
     /// @brief Event that triggers when a sample send is completed

--- a/monodrive/core/src/DistributedServer.h
+++ b/monodrive/core/src/DistributedServer.h
@@ -113,6 +113,7 @@ public:
     virtual bool sendCommand(ApiMessage message, nlohmann::json* response=nullptr);
     /// @brief Send command to server and return immediately
     virtual bool sendCommandAsync(ApiMessage message, nlohmann::json* response=nullptr);
+    Simulator* GetSimulator();
 
 
     /// @brief Event that triggers when a sample send is completed

--- a/monodrive/core/src/Simulator.h
+++ b/monodrive/core/src/Simulator.h
@@ -57,10 +57,10 @@ public:
 
 	const std::string& getServerIp() const{return serverIp;}
 	const short& getServerPort() const{return serverPort;}
-private:
 	Simulator(const Configuration& config);
 	Simulator(const std::string& serverIp, const short& serverPort);
 	Simulator(const Configuration& config, const std::string& serverIp, const short& serverPort);
+private:
 	Simulator(const Simulator&)= delete;
 	void waitForSamples(const std::vector<std::shared_ptr<Sensor>>& sensors);
   	Simulator& operator=(const Simulator&)= delete;

--- a/monodrive/core/src/Simulator.h
+++ b/monodrive/core/src/Simulator.h
@@ -57,10 +57,10 @@ public:
 
 	const std::string& getServerIp() const{return serverIp;}
 	const short& getServerPort() const{return serverPort;}
-	Simulator(const Configuration& config);
 	Simulator(const std::string& serverIp, const short& serverPort);
-	Simulator(const Configuration& config, const std::string& serverIp, const short& serverPort);
 private:
+	Simulator(const Configuration& config);
+	Simulator(const Configuration& config, const std::string& serverIp, const short& serverPort);
 	Simulator(const Simulator&)= delete;
 	void waitForSamples(const std::vector<std::shared_ptr<Sensor>>& sensors);
   	Simulator& operator=(const Simulator&)= delete;


### PR DESCRIPTION
Simulator constructor public
Create connection for control.
Add callback to ros distributed example.
The purpose of this PR is to enable multiple threads to connect and send commands on the control channel (i.e., same port/ip).