### PR TITLE
Speed control example

### DIFF
--- a/examples/cpp/lane_follower/fixed_step.cpp
+++ b/examples/cpp/lane_follower/fixed_step.cpp
@@ -5,11 +5,12 @@
 #include <vector>
 #include <future>
 
-//monoDrive Includes
+// monoDrive includes
 #include "Simulator.h"
 #include "Configuration.h"  // holder for sensor, simulator, scenario, weather, and vehicle configurations
 #include "Sensor.h"
 #include "sensor_config.h"
+#include "DataFrame.h"
 #include "Stopwatch.h"
 
 #include "opencv2/core.hpp"
@@ -18,7 +19,7 @@
 #include "opencv2/imgproc.hpp"
 
 #include "LaneSpline.h"
-#include "DataFrame.h"
+#include "pid.h"
 
 using namespace lane_spline;
 
@@ -27,11 +28,17 @@ LaneSpline lanespline = LaneSpline(std::string("examples/cpp/lane_follower/Strai
 #define IMG_WIDTH 1920
 #define IMG_HEIGHT 1080
 
-//Single Simulator Example
+// simulator server
 std::string server0_ip = "127.0.0.1";
-int server_port = 8999;   // This has to be 8999 this simulator is listening for connections on this port;
+int server_port = 8999;
 
-EgoControlConfig planning(DataFrame* dataFrame){
+// speed control
+PID pid(0.0125f, 0.004f, 0.0025f, -1.0f, 1.0f);
+float last_time = 0;
+float desired_speed = 1000.0;
+
+
+EgoControlConfig planning(DataFrame* dataFrame) {
     auto& frame = *static_cast<StateFrame*>(dataFrame);
 
     VehicleState* vehicle_frame = nullptr;
@@ -48,6 +55,7 @@ EgoControlConfig planning(DataFrame* dataFrame){
         return EgoControlConfig();
     }
 
+    // use lane follower for steering
     Eigen::VectorXd position(3);
     position << vehicle_frame->state.odometry.pose.position.x,
         vehicle_frame->state.odometry.pose.position.y,
@@ -76,9 +84,22 @@ EgoControlConfig planning(DataFrame* dataFrame){
 
     double angle = -dirToNextPoint.head<3>().cross(forwardVector.head<3>())[2];
 
+    // use PID speed controller for throttle
+    Eigen::VectorXd velocity(3);
+    velocity << vehicle_frame->state.odometry.linear_velocity.x,
+        vehicle_frame->state.odometry.linear_velocity.y,
+        vehicle_frame->state.odometry.linear_velocity.z;
+    double speed = velocity.norm();
+
+    double dt = last_time ? frame.game_time - last_time : 0.1;
+    last_time = frame.game_time;
+
+    float throttle = pid.pid(desired_speed - speed, dt);
+
+    // form controls response
     EgoControlConfig egoControl;
-    egoControl.forward_amount = 0.75;
-    egoControl.brake_amount = 0.0;
+    egoControl.forward_amount = std::max(0.0f, throttle);
+    egoControl.brake_amount = std::min(0.0f, throttle);
     egoControl.drive_mode = 1;
     egoControl.right_amount = (float)angle;
     return egoControl;

--- a/examples/cpp/lane_follower/fixed_step.cpp
+++ b/examples/cpp/lane_follower/fixed_step.cpp
@@ -25,8 +25,8 @@ using namespace lane_spline;
 
 LaneSpline lanespline = LaneSpline(std::string("examples/cpp/lane_follower/Straightaway5k.json"));
 
-#define IMG_WIDTH 1920
-#define IMG_HEIGHT 1080
+#define IMG_WIDTH 1280
+#define IMG_HEIGHT 720
 
 // simulator server
 std::string server0_ip = "127.0.0.1";

--- a/examples/cpp/lane_follower/fixed_step_lidar.cpp
+++ b/examples/cpp/lane_follower/fixed_step_lidar.cpp
@@ -5,11 +5,12 @@
 #include <vector>
 #include <future>
 
-//monoDrive Includes
+// monoDrive includes
 #include "Simulator.h"
 #include "Configuration.h"  // holder for sensor, simulator, scenario, weather, and vehicle configurations
 #include "Sensor.h"
 #include "sensor_config.h"
+#include "DataFrame.h"
 #include "Stopwatch.h"
 
 #include "opencv2/core.hpp"
@@ -18,7 +19,7 @@
 #include "opencv2/imgproc.hpp"
 
 #include "LaneSpline.h"
-#include "DataFrame.h"
+#include "pid.h"
 
 using namespace lane_spline;
 
@@ -27,11 +28,17 @@ LaneSpline lanespline = LaneSpline(std::string("examples/cpp/lane_follower/Strai
 #define IMG_WIDTH 1920
 #define IMG_HEIGHT 1080
 
-//Single Simulator Example
+// simulator server
 std::string server0_ip = "127.0.0.1";
-int server_port = 8999;   // This has to be 8999 this simulator is listening for connections on this port;
+int server_port = 8999;
 
-EgoControlConfig planning(DataFrame* dataFrame){
+// speed control
+PID pid(0.0125f, 0.004f, 0.0025f, -1.0f, 1.0f);
+float last_time = 0;
+float desired_speed = 1000.0;
+
+
+EgoControlConfig planning(DataFrame* dataFrame) {
     auto& frame = *static_cast<StateFrame*>(dataFrame);
 
     VehicleState* vehicle_frame = nullptr;
@@ -48,6 +55,7 @@ EgoControlConfig planning(DataFrame* dataFrame){
         return EgoControlConfig();
     }
 
+    // use lane follower for steering
     Eigen::VectorXd position(3);
     position << vehicle_frame->state.odometry.pose.position.x,
         vehicle_frame->state.odometry.pose.position.y,
@@ -76,9 +84,22 @@ EgoControlConfig planning(DataFrame* dataFrame){
 
     double angle = -dirToNextPoint.head<3>().cross(forwardVector.head<3>())[2];
 
+    // use PID speed controller for throttle
+    Eigen::VectorXd velocity(3);
+    velocity << vehicle_frame->state.odometry.linear_velocity.x,
+        vehicle_frame->state.odometry.linear_velocity.y,
+        vehicle_frame->state.odometry.linear_velocity.z;
+    double speed = velocity.norm();
+
+    double dt = last_time ? frame.game_time - last_time : 0.1;
+    last_time = frame.game_time;
+
+    float throttle = pid.pid(desired_speed - speed, dt);
+
+    // form controls response
     EgoControlConfig egoControl;
-    egoControl.forward_amount = 0.75;
-    egoControl.brake_amount = 0.0;
+    egoControl.forward_amount = std::max(0.0f, throttle);
+    egoControl.brake_amount = std::min(0.0f, throttle);
     egoControl.drive_mode = 1;
     egoControl.right_amount = (float)angle;
     return egoControl;

--- a/examples/cpp/lane_follower/fixed_step_lidar.cpp
+++ b/examples/cpp/lane_follower/fixed_step_lidar.cpp
@@ -25,8 +25,8 @@ using namespace lane_spline;
 
 LaneSpline lanespline = LaneSpline(std::string("examples/cpp/lane_follower/Straightaway5k.json"));
 
-#define IMG_WIDTH 1920
-#define IMG_HEIGHT 1080
+#define IMG_WIDTH 1280
+#define IMG_HEIGHT 720
 
 // simulator server
 std::string server0_ip = "127.0.0.1";

--- a/examples/cpp/lane_follower/pid.h
+++ b/examples/cpp/lane_follower/pid.h
@@ -1,0 +1,56 @@
+// PID controller
+
+#include <limits>
+
+class PID {
+public:
+    PID(
+        float kp = 1.f,
+        float ki = 0.f,
+        float kd = 0.f,
+        float outputMin = std::numeric_limits<float>::lowest(),
+        float outputMax = std::numeric_limits<float>::max())
+        : kp(kp), ki(ki), kd(kd),
+          outputMin(outputMin),
+          outputMax(outputMax)
+    {}
+
+    float inline pid(float error, float dt)
+    {
+        integral += (error * dt);
+        float derivative = (error - error_prior) / dt;
+        error_prior = error;
+        float output = kp * error + ki * integral + kd * derivative;
+
+        if (output > outputMax)
+        {
+            integral -= output - outputMax;
+            return outputMax;
+        }
+        else if (output < outputMin)
+        {
+            integral += outputMin - output;
+            return outputMin;
+        }
+        else
+        {
+            return output;
+        }
+    }
+
+    void inline reset()
+    {
+        integral = 0.f;
+        error_prior = 0.f;
+    }
+
+    float kp = 1;
+	float ki = 0;
+	float kd = 0;
+    float outputMin = std::numeric_limits<float>::lowest();
+	float outputMax = std::numeric_limits<float>::max();
+
+protected:
+	float integral = 0.f;
+	float error_prior = 0.f;
+};

--- a/examples/cpp/lane_follower/real_time.cpp
+++ b/examples/cpp/lane_follower/real_time.cpp
@@ -5,11 +5,12 @@
 #include <vector>
 #include <future>
 
-//monoDrive Includes
+// monoDrive includes
 #include "Simulator.h"
-#include "Configuration.h"  // holder for sensor, simulator, scenario, weather, and vehicle configurations
+#include "Configuration.h"
 #include "Sensor.h"
 #include "sensor_config.h"
+#include "DataFrame.h"
 #include "Stopwatch.h"
 
 #include "opencv2/core.hpp"
@@ -18,21 +19,26 @@
 #include "opencv2/imgproc.hpp"
 
 #include "LaneSpline.h"
-#include "DataFrame.h"
+#include "pid.h"
 
 using namespace lane_spline;
 
 LaneSpline lanespline = LaneSpline(std::string("examples/cpp/lane_follower/Straightaway5k.json"));
 
-#define IMG_WIDTH 1920
-#define IMG_HEIGHT 1080
+#define IMG_WIDTH 512
+#define IMG_HEIGHT 512
 
-//Single Simulator Example
+// simulator server
 std::string server0_ip = "127.0.0.1";
-int server_port = 8999;   // This has to be 8999 this simulator is listening for connections on this port;
+int server_port = 8999;
+
+// speed control
+PID pid(0.0125f, 0.004f, 0.0025f, -1.0f, 1.0f);
+float last_time = 0;
+float desired_speed = 1500.0;
 
 
-EgoControlConfig planning(DataFrame* dataFrame){
+EgoControlConfig planning(DataFrame* dataFrame) {
     auto& frame = *static_cast<StateFrame*>(dataFrame);
     std::cout << "sample, game, wall " << frame.sample_count << " " << frame.game_time << " " << frame.wall_time << std::endl;
 
@@ -50,6 +56,7 @@ EgoControlConfig planning(DataFrame* dataFrame){
         return EgoControlConfig();
     }
 
+    // use lane follower for steering
     Eigen::VectorXd position(3);
     position << vehicle_frame->state.odometry.pose.position.x,
         vehicle_frame->state.odometry.pose.position.y,
@@ -78,13 +85,27 @@ EgoControlConfig planning(DataFrame* dataFrame){
 
     double angle = -dirToNextPoint.head<3>().cross(forwardVector.head<3>())[2];
 
+    // use PID speed controller for throttle
+    Eigen::VectorXd velocity(3);
+    velocity << vehicle_frame->state.odometry.linear_velocity.x,
+        vehicle_frame->state.odometry.linear_velocity.y,
+        vehicle_frame->state.odometry.linear_velocity.z;
+    double speed = velocity.norm();
+
+    double dt = last_time ? frame.game_time - last_time : 0.1;
+    last_time = frame.game_time;
+
+    float throttle = pid.pid(desired_speed - speed, dt);
+
+    // form controls response
     EgoControlConfig egoControl;
-    egoControl.forward_amount = 0.75;
-    egoControl.brake_amount = 0.0;
+    egoControl.forward_amount = std::max(0.0f, throttle);
+    egoControl.brake_amount = std::min(0.0f, throttle);
     egoControl.drive_mode = 1;
     egoControl.right_amount = (float)angle;
     return egoControl;
 }
+
 
 void perception(DataFrame* dataFrame) {
     auto camFrame = static_cast<CameraFrame *>(dataFrame);


### PR DESCRIPTION
## Overview
This adds a PID speed controller to the lane follower examples

## Changes
- adds PID controller utility class
- use PID controller to implement speed control in lane follower examples
- use 720p cameras in lane follower examples

## Testing
Run any of the lane follower examples, and ensure vehicle speed stabilizes at 10m/s