### PR TITLE
Fix `getEgoVehicleId` in Linux

### DIFF
--- a/monodrive/core/src/Simulator.cpp
+++ b/monodrive/core/src/Simulator.cpp
@@ -366,7 +366,7 @@ bool Simulator::sendControl(float forward, float right, float brake, int mode)
 }
 
 std::string Simulator::getEgoVehicleId() {
-	auto& getEgoVehicleName = [](nlohmann::json& vehicles) {
+	const auto getEgoVehicleName = [](nlohmann::json& vehicles) {
 		for (auto& obj : vehicles) {
 			nlohmann::json vehicle = obj;
 			if (obj.find("state") != obj.end()) {


### PR DESCRIPTION
## Overview

This fixes a build issue with gcc version 7.5 that was introduced in #100 and reported in #108.


## Changes

Fixed the build issue by making the function `const`

## Testing

Ensure the client code builds on gcc 7.5+ and Windows.

Run the  lights example to see that the function works correctly.

Closes #108 