### PR TITLE
Imager example

### DIFF
--- a/examples/config/imager.json
+++ b/examples/config/imager.json
@@ -32,8 +32,8 @@
         "steer_forward_distance_lane_change": 1500.0
       },
       "location": {
-        "x": 6170.0,
-        "y": 960.0,
+        "x": 7782.835449,
+        "y": -33.783367,
         "z": 10.0
       },
       "name": "crossover_monoDrive_01_5",

--- a/examples/config/imager.json
+++ b/examples/config/imager.json
@@ -1,0 +1,57 @@
+{
+  "trigger_boxes": [],
+  "vehicles": [
+    {
+      "behavior_settings": {
+        "destroy_on_collision": false,
+        "ignore_lane_change_boxes": false,
+        "ignore_other_vehicles": false,
+        "ignore_traffic_signals": false,
+        "initial_speed_is_delta": true,
+        "limit_speed_in_curves": true,
+        "obey_road_speed_limits": true,
+        "overtake_slower_vehicles": false,
+        "snap_to_lane": true
+      },
+      "body_color": "Carpaint_White",
+      "class_path": "/Game/Vehicles/crossover_monoDrive_01.crossover_monoDrive_01_C",
+      "controller_settings": {
+        "delayed_start": 0.0,
+        "distance_to_stop_sign": 400.0,
+        "initial_speed": 0.0,
+        "lane_offset": 0.0,
+        "rolling_stop_speed": 0.0010000000474974513,
+        "search_forward_distance": 10000.0,
+        "set_speed": 0.0,
+        "spawn_offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "steer_forward_distance": 600.0,
+        "steer_forward_distance_lane_change": 1500.0
+      },
+      "location": {
+        "x": 6170.0,
+        "y": 960.0,
+        "z": 10.0
+      },
+      "name": "crossover_monoDrive_01_5",
+      "rotation": {
+        "pitch": 0.0,
+        "roll": 0.0,
+        "yaw": 0.0
+      },
+      "scale": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0
+      },
+      "tags": [
+        "vehicle",
+        "dynamic",
+        "ego"
+      ]
+    }
+  ]
+}

--- a/examples/config/simulator_imager.json
+++ b/examples/config/simulator_imager.json
@@ -1,0 +1,108 @@
+{
+  "id": "simulator_test",
+  "server_ip": "127.0.0.1",
+  "server_port": 8999,
+  "client_ip": "127.0.0.1",
+  "map": "Almono",
+  "simulation_mode": 0,
+  "phys_materials": {
+    "Aluminum": {
+      "specular_exponent": 15.0,
+      "specular_coefficient": 0.95,
+      "diffuse_coefficient": 0.26,
+      "dielectric_constant": 10.0,
+      "roughness": 0.15
+    },
+    "Asphalt": {
+      "specular_exponent": 1.0,
+      "specular_coefficient": 0.03,
+      "diffuse_coefficient": 0.65,
+      "dielectric_constant": 7.0,
+      "roughness": 0.65
+    },
+    "Road": {
+      "specular_exponent": 1.0,
+      "specular_coefficient": 0.1,
+      "diffuse_coefficient": 0.65,
+      "dielectric_constant": 7.0,
+      "roughness": 0.65
+    },
+    "Concrete": {
+      "specular_exponent": 0.0,
+      "specular_coefficient": 0.1,
+      "diffuse_coefficient": 0.65,
+      "dielectric_constant": 7.0,
+      "roughness": 0.0
+    },
+    "Glass": {
+      "specular_exponent": 80.0,
+      "specular_coefficient": 0.80,
+      "diffuse_coefficient": 0.15,
+      "dielectric_constant": 4.0,
+      "roughness": 0.10
+    },
+    "LandScape": {
+      "specular_exponent": 10.0,
+      "specular_coefficient": 0.50,
+      "diffuse_coefficient": 0.50,
+      "dielectric_constant": 10.0,
+      "roughness": 0.60
+    },
+    "Plastic": {
+      "specular_exponent": 25.0,
+      "specular_coefficient": 0.40,
+      "diffuse_coefficient": 0.60,
+      "dielectric_constant": 2.8,
+      "roughness": 0.09
+    },
+    "Steel": {
+      "specular_exponent": 26.0,
+      "specular_coefficient": 1.0,
+      "diffuse_coefficient": 0.33,
+      "dielectric_constant": 0.0,
+      "roughness": 0.23
+    },
+    "Tree": {
+      "specular_exponent": 10.0,
+      "specular_coefficient": 0.05,
+      "diffuse_coefficient": 0.97,
+      "dielectric_constant": 10.0,
+      "roughness": 0.60
+    },
+    "Wheel": {
+      "specular_exponent": 92.0,
+      "specular_coefficient": 0.95,
+      "diffuse_coefficient": 0.06,
+      "dielectric_constant": 10.0,
+      "roughness": 0.15
+    },
+    "Tire": {
+      "specular_exponent": 25.0,
+      "specular_coefficient": 0.40,
+      "diffuse_coefficient": 0.60,
+      "dielectric_constant": 2.8,
+      "roughness": 0.15
+    }
+  },
+  "traffic_configuration": {
+    "max_vehicles": 0,
+    "spawn_rate": 0.25
+  },
+  "client_settings": {
+    "map": {
+      "gis_anchor": { "x": 0, "y": 0, "z": 0},
+      "point_delta": 100.0
+    },
+    "gui":{
+      "fps": 1.0
+    },
+    "logger": {
+      "sensor": "debug",
+      "network": "info",
+      "control": "info",
+      "scenario": "info",
+      "simulator": "info",
+      "vehicle": "info"
+    }
+  }
+}

--- a/examples/cpp/dev/CMakeLists.txt
+++ b/examples/cpp/dev/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(fisheye_camera_equidistant fisheye_camera_equidistant.cpp)
 add_executable(fisheye_camera_poly1 fisheye_camera_poly1.cpp)
 add_executable(sensors_from_json sensors_from_json.cpp)
 add_executable(multi_connection multi_connection.cpp)
+add_executable(imager imager.cpp)
 
 # link monodrive client
 target_link_libraries(camera_sensor monodrive)
@@ -62,6 +63,7 @@ target_link_libraries(fisheye_camera_equidistant monodrive)
 target_link_libraries(fisheye_camera_poly1 monodrive)
 target_link_libraries(sensors_from_json monodrive)
 target_link_libraries(multi_connection monodrive)
+target_link_libraries(imager monodrive)
 
 # copy monodrive dll to runtime directory
 if(MSVC)
@@ -99,6 +101,7 @@ if(MSVC)
   add_dependencies(fisheye_camera_poly1 monodrive_lib_copy_dev)
   add_dependencies(sensors_from_json monodrive_lib_copy_dev)
   add_dependencies(multi_connection monodrive_lib_copy_dev)
+  add_dependencies(imager monodrive_lib_copy_dev)
 endif(MSVC)
 
 # eigen
@@ -163,6 +166,10 @@ target_link_libraries(sensors_from_json ${OpenCV_LIBRARIES})
 target_include_directories(multi_connection PUBLIC ${OpenCV_INCLUDE_DIRS})
 link_libraries(multi_connection ${OpenCV_LIBRARIES})
 target_link_libraries(multi_connection ${OpenCV_LIBRARIES})
+
+target_include_directories(imager PUBLIC ${OpenCV_INCLUDE_DIRS})
+link_libraries(imager ${OpenCV_LIBRARIES})
+target_link_libraries(imager ${OpenCV_LIBRARIES})
 
 # filesystem
 target_link_libraries(config_export -lstdc++fs)

--- a/examples/cpp/dev/CMakeLists.txt
+++ b/examples/cpp/dev/CMakeLists.txt
@@ -33,7 +33,8 @@ add_executable(fisheye_camera_equidistant fisheye_camera_equidistant.cpp)
 add_executable(fisheye_camera_poly1 fisheye_camera_poly1.cpp)
 add_executable(sensors_from_json sensors_from_json.cpp)
 add_executable(multi_connection multi_connection.cpp)
-add_executable(imager imager.cpp)
+add_executable(imager_rggb imager_rggb.cpp)
+add_executable(imager_rccc imager_rccc.cpp)
 
 # link monodrive client
 target_link_libraries(camera_sensor monodrive)
@@ -63,7 +64,8 @@ target_link_libraries(fisheye_camera_equidistant monodrive)
 target_link_libraries(fisheye_camera_poly1 monodrive)
 target_link_libraries(sensors_from_json monodrive)
 target_link_libraries(multi_connection monodrive)
-target_link_libraries(imager monodrive)
+target_link_libraries(imager_rggb monodrive)
+target_link_libraries(imager_rccc monodrive)
 
 # copy monodrive dll to runtime directory
 if(MSVC)
@@ -101,7 +103,8 @@ if(MSVC)
   add_dependencies(fisheye_camera_poly1 monodrive_lib_copy_dev)
   add_dependencies(sensors_from_json monodrive_lib_copy_dev)
   add_dependencies(multi_connection monodrive_lib_copy_dev)
-  add_dependencies(imager monodrive_lib_copy_dev)
+  add_dependencies(imager_rggb monodrive_lib_copy_dev)
+  add_dependencies(imager_rccc monodrive_lib_copy_dev)
 endif(MSVC)
 
 # eigen
@@ -167,9 +170,13 @@ target_include_directories(multi_connection PUBLIC ${OpenCV_INCLUDE_DIRS})
 link_libraries(multi_connection ${OpenCV_LIBRARIES})
 target_link_libraries(multi_connection ${OpenCV_LIBRARIES})
 
-target_include_directories(imager PUBLIC ${OpenCV_INCLUDE_DIRS})
-link_libraries(imager ${OpenCV_LIBRARIES})
-target_link_libraries(imager ${OpenCV_LIBRARIES})
+target_include_directories(imager_rggb PUBLIC ${OpenCV_INCLUDE_DIRS})
+link_libraries(imager_rggb ${OpenCV_LIBRARIES})
+target_link_libraries(imager_rggb ${OpenCV_LIBRARIES})
+
+target_include_directories(imager_rccc PUBLIC ${OpenCV_INCLUDE_DIRS})
+link_libraries(imager_rccc ${OpenCV_LIBRARIES})
+target_link_libraries(imager_rccc ${OpenCV_LIBRARIES})
 
 # filesystem
 target_link_libraries(config_export -lstdc++fs)

--- a/examples/cpp/dev/imager.cpp
+++ b/examples/cpp/dev/imager.cpp
@@ -1,0 +1,86 @@
+#include <iostream>		  // std::cout
+#include <chrono>		  // std::chrono	
+#include <thread>         // std::thread
+#include <memory>
+#include <vector>
+#include <future>
+
+//monoDrive Includes
+#include "Simulator.h"
+#include "Configuration.h"  // holder for sensor, simulator, scenario, weather, and vehicle configurations
+#include "Sensor.h"
+#include "sensor_config.h"
+
+#include "opencv2/core.hpp"
+#include "opencv2/core/utility.hpp"
+#include "opencv2/highgui.hpp"
+#include "opencv2/imgproc.hpp"
+
+#define IMG_WIDTH 1280
+#define IMG_HEIGHT 800
+
+int main(int argc, char** argv)
+{
+    //Single Simulator Example
+    std::string server0_ip = "127.0.0.1";
+    int server_port = 8999;   // This has to be 8999 this simulator is listening for connections on this port;
+
+    Configuration config(
+        "examples/config/simulator_fisheye.json",
+        "examples/config/weather.json",
+        "examples/config/fisheye.json"
+    );
+    // swap to this for interesting scenario with a fisheye camera
+    Simulator sim0(config, server0_ip, server_port);
+
+    // Configure simulator
+    if(!sim0.configure()){
+        return -1;
+    }
+
+    // Configure the sensors we wish to use
+    std::vector<std::shared_ptr<Sensor>> sensors;
+
+    CameraConfig fc_config;
+    fc_config.server_ip = sim0.getServerIp();
+    fc_config.server_port = sim0.getServerPort();
+    fc_config.listen_port = 8100;
+    fc_config.location.z = 225;
+    fc_config.resolution = Resolution(IMG_WIDTH,IMG_HEIGHT);
+    sensors.push_back(std::make_shared<Sensor>(std::make_unique<CameraConfig>(fc_config)));
+
+    ViewportCameraConfig vp_config;
+    vp_config.server_ip = sim0.getServerIp();
+    vp_config.server_port = sim0.getServerPort();
+    vp_config.location.z = 200;
+    vp_config.resolution = Resolution(256,256);
+    Sensor(std::make_unique<ViewportCameraConfig>(vp_config)).configure();
+
+    // Send configurations to the simulator
+    std::cout<<"***********ALL SENSOR's CONFIGS*******"<<std::endl;
+    for (auto& sensor : sensors)
+    {
+        sensor->configure();
+    }
+
+    sensors[0]->sampleCallback = [](DataFrame *frame) {
+        auto camFrame = static_cast<CubeCameraFrame *>(frame);
+        auto imFrame = camFrame->imageFrame;
+        cv::Mat img;
+        if (imFrame->channels == 4)
+        {
+            img = cv::Mat(imFrame->resolution.y, imFrame->resolution.x, CV_8UC4,
+                          imFrame->pixels);
+        }
+        cv::imshow("monoDrive 0", img);
+        cv::waitKey(1);
+    };
+
+    std::cout << "Sampling sensor loop" << std::endl;
+    while(true)
+    {
+        sim0.sampleAll(sensors);
+    }
+
+    return 0;
+}

--- a/examples/cpp/dev/imager.cpp
+++ b/examples/cpp/dev/imager.cpp
@@ -16,8 +16,8 @@
 #include "opencv2/highgui.hpp"
 #include "opencv2/imgproc.hpp"
 
-#define IMG_WIDTH 1280
-#define IMG_HEIGHT 800
+#define IMG_WIDTH 480
+#define IMG_HEIGHT 318
 
 int main(int argc, char** argv)
 {
@@ -63,8 +63,9 @@ int main(int argc, char** argv)
         sensor->configure();
     }
 
-    sensors[0]->sampleCallback = [](DataFrame *frame) {
-        auto camFrame = static_cast<CubeCameraFrame *>(frame);
+    int count = 0;
+    sensors[0]->sampleCallback = [&count](DataFrame *frame) {
+        auto camFrame = static_cast<CameraFrame*>(frame);
         auto imFrame = camFrame->imageFrame;
         cv::Mat img;
         if (imFrame->channels == 4)
@@ -72,6 +73,17 @@ int main(int argc, char** argv)
             img = cv::Mat(imFrame->resolution.y, imFrame->resolution.x, CV_8UC4,
                           imFrame->pixels);
         }
+        else
+            return;
+        
+        if(count++ == 50){
+            cv::cvtColor(img, img, cv::COLOR_BGRA2BGR);
+            cv::imwrite("img.png", img);
+            cv::Mat gray;
+            cv::cvtColor(img, gray, cv::COLOR_BGR2GRAY);
+            cv::imwrite("gray.png", gray);
+        }
+
         cv::imshow("monoDrive 0", img);
         cv::waitKey(1);
     };

--- a/examples/cpp/dev/imager.cpp
+++ b/examples/cpp/dev/imager.cpp
@@ -81,8 +81,8 @@ int main(int argc, char** argv)
         sensor->configure();
     }
 
-    int count = 0;
-    sensors[0]->sampleCallback = [&count](DataFrame *frame) {
+    int count1 = 0;
+    sensors[0]->sampleCallback = [&count1](DataFrame *frame) {
         auto camFrame = static_cast<CameraFrame*>(frame);
         auto imFrame = camFrame->imageFrame;
         cv::Mat img;
@@ -97,22 +97,19 @@ int main(int argc, char** argv)
         cv::cvtColor(img, img, cv::COLOR_BGRA2BGR);
         cv::Mat1b red;
         cv::extractChannel(img, red, 0); 
-        if(count++ == 50){
-
-            // cv::Mat gray;
-            // cv::cvtColor(img, gray, cv::COLOR_BGR2GRAY);
-            // cv::imwrite("gray.png", gray);
-            cv::imwrite("img.png", img);
-            cv::imwrite("red_pass.png", red);
-        }
 
         cv::Mat color;
         cv::cvtColor(red, color, cv::COLOR_BayerBG2BGR);
+        if(count1++ == 50){
+            cv::imwrite("de_bayered.png", color);
+            cv::imwrite("bayer.png", red);
+        }
         cv::imshow("de-bayered", color);
         cv::imshow("bayer", img);
         cv::waitKey(1);
     };
-    sensors[1]->sampleCallback = [&count](DataFrame *frame) {
+    int count2 = 0;
+    sensors[1]->sampleCallback = [&count2](DataFrame *frame) {
         auto camFrame = static_cast<CameraFrame*>(frame);
         auto imFrame = camFrame->imageFrame;
         cv::Mat img;
@@ -123,6 +120,9 @@ int main(int argc, char** argv)
         }
         else
             return;
+        if(count2++ == 50){
+            cv::imwrite("rgb.png", img);
+        }
         cv::imshow("rgb", img);
         cv::waitKey(1);
     };

--- a/examples/cpp/dev/imager.cpp
+++ b/examples/cpp/dev/imager.cpp
@@ -76,15 +76,19 @@ int main(int argc, char** argv)
         else
             return;
         
+        cv::cvtColor(img, img, cv::COLOR_BGRA2BGR);
+        cv::Mat1b red;
+        cv::extractChannel(img, red, 2); 
         if(count++ == 50){
-            cv::cvtColor(img, img, cv::COLOR_BGRA2BGR);
+
+            // cv::Mat gray;
+            // cv::cvtColor(img, gray, cv::COLOR_BGR2GRAY);
+            // cv::imwrite("gray.png", gray);
             cv::imwrite("img.png", img);
-            cv::Mat gray;
-            cv::cvtColor(img, gray, cv::COLOR_BGR2GRAY);
-            cv::imwrite("gray.png", gray);
+            cv::imwrite("red_pass.png", red);
         }
 
-        cv::imshow("monoDrive 0", img);
+        cv::imshow("monoDrive 0", red);
         cv::waitKey(1);
     };
 

--- a/examples/cpp/dev/imager_rccc.cpp
+++ b/examples/cpp/dev/imager_rccc.cpp
@@ -84,8 +84,7 @@ int main(int argc, char** argv)
         sensor->configure();
     }
 
-    int count1 = 0;
-    sensors[0]->sampleCallback = [&count1](DataFrame *frame) {
+    sensors[0]->sampleCallback = [](DataFrame *frame) {
         auto camFrame = static_cast<CameraFrame*>(frame);
         auto imFrame = camFrame->imageFrame;
         cv::Mat img;
@@ -94,30 +93,24 @@ int main(int argc, char** argv)
             img = cv::Mat(imFrame->resolution.y, imFrame->resolution.x, CV_8UC4,
                           imFrame->pixels);
         }
-        else
+        else{
+            std::cout << "Error, cfa cameras use 4 channels. channel set to " << imFrame->channels << std::endl;
             return;
+        }
         
         // just to make the gray image smaller when saved
         cv::Mat1b rccc;
         cv::extractChannel(img, rccc, 2); 
-        if(count1++ == 50){
-            // saving a copy of one of the streamed images
-            cv::imwrite("rccc.png", rccc);
-        }
         cv::imshow("rccc", rccc);
         cv::waitKey(1);
     };
     // an gray rendered image for comparison
-    int count2 = 0;
-    sensors[1]->sampleCallback = [&count2](DataFrame *frame) {
+    sensors[1]->sampleCallback = [](DataFrame *frame) {
         auto camFrame = static_cast<CameraFrame*>(frame);
         auto imFrame = camFrame->imageFrame;
         cv::Mat img;
         img = cv::Mat(imFrame->resolution.y, imFrame->resolution.x, CV_8UC1,
                           imFrame->pixels);
-        if(count2++ == 50){
-            cv::imwrite("gray.png", img);
-        }
         cv::imshow("gray", img);
         cv::waitKey(1);
     };

--- a/examples/cpp/dev/imager_rggb.cpp
+++ b/examples/cpp/dev/imager_rggb.cpp
@@ -98,9 +98,6 @@ int main(int argc, char** argv)
         
         // just to make the rgb image smaller when saved
         cv::cvtColor(img, img, cv::COLOR_BGRA2BGR);
-        // std::cout << (int)img.at<cv::Vec3b>(0,0)[0] << " " 
-        //     << (int)img.at<cv::Vec3b>(0,0)[1] << " " 
-        //     << (int)img.at<cv::Vec3b>(0,0)[2] << " " <<std::endl;
         cv::Mat1b rggb;
         cv::extractChannel(img, rggb, 2); 
         std::cout << rggb.size() << std::endl;
@@ -110,7 +107,7 @@ int main(int argc, char** argv)
         if(count1++ == 50){
             // saving a copy of one of the streamed images
             cv::imwrite("de_bayered.png", color);
-            cv::imwrite("bayer.png", rggb);
+            cv::imwrite("rggb.png", rggb);
         }
         cv::imshow("de-bayered", color);
         cv::imshow("bayer", rggb);

--- a/examples/cpp/dev/imager_rggb.cpp
+++ b/examples/cpp/dev/imager_rggb.cpp
@@ -48,7 +48,6 @@ int main(int argc, char** argv)
     fc_config.listen_port = 8100;
     fc_config.location.x = 70;
     fc_config.location.z = 170;
-    // fc_config.color_filter_array.cfa = "rccc";
     fc_config.color_filter_array.cfa = "rggb";
     fc_config.color_filter_array.use_cfa = true;
 
@@ -83,8 +82,7 @@ int main(int argc, char** argv)
         sensor->configure();
     }
 
-    int count1 = 0;
-    sensors[0]->sampleCallback = [&count1](DataFrame *frame) {
+    sensors[0]->sampleCallback = [](DataFrame *frame) {
         auto camFrame = static_cast<CameraFrame*>(frame);
         auto imFrame = camFrame->imageFrame;
         cv::Mat img;
@@ -104,18 +102,12 @@ int main(int argc, char** argv)
 
         cv::Mat color;
         cv::cvtColor(rggb, color, cv::COLOR_BayerBG2BGR);
-        if(count1++ == 50){
-            // saving a copy of one of the streamed images
-            cv::imwrite("de_bayered.png", color);
-            cv::imwrite("rggb.png", rggb);
-        }
         cv::imshow("de-bayered", color);
         cv::imshow("bayer", rggb);
         cv::waitKey(1);
     };
     // an rgb rendered image for comparison
-    int count2 = 0;
-    sensors[1]->sampleCallback = [&count2](DataFrame *frame) {
+    sensors[1]->sampleCallback = [](DataFrame *frame) {
         auto camFrame = static_cast<CameraFrame*>(frame);
         auto imFrame = camFrame->imageFrame;
         cv::Mat img;
@@ -124,10 +116,9 @@ int main(int argc, char** argv)
             img = cv::Mat(imFrame->resolution.y, imFrame->resolution.x, CV_8UC4,
                           imFrame->pixels);
         }
-        else
+        else{
+            std::cout << "Error, cfa cameras use 4 channels. channel set to " << imFrame->channels << std::endl;
             return;
-        if(count2++ == 50){
-            cv::imwrite("rgb.png", img);
         }
         cv::imshow("rgb", img);
         cv::waitKey(1);

--- a/examples/cpp/dev/imager_rggb.cpp
+++ b/examples/cpp/dev/imager_rggb.cpp
@@ -91,8 +91,10 @@ int main(int argc, char** argv)
             img = cv::Mat(imFrame->resolution.y, imFrame->resolution.x, CV_8UC4,
                           imFrame->pixels);
         }
-        else
+        else{
+            std::cout << "Error, cfa cameras use 4 channels. channel set to " << imFrame->channels << std::endl;
             return;
+        }
         
         // just to make the rgb image smaller when saved
         cv::cvtColor(img, img, cv::COLOR_BGRA2BGR);
@@ -117,7 +119,7 @@ int main(int argc, char** argv)
                           imFrame->pixels);
         }
         else{
-            std::cout << "Error, cfa cameras use 4 channels. channel set to " << imFrame->channels << std::endl;
+            std::cout << "Error, rgb cameras are 4 channel. Channel set to " << imFrame->channels << std::endl;
             return;
         }
         cv::imshow("rgb", img);

--- a/examples/cpp/dev/imager_rggb.cpp
+++ b/examples/cpp/dev/imager_rggb.cpp
@@ -1,0 +1,146 @@
+#include <iostream>		  // std::cout
+#include <chrono>		  // std::chrono	
+#include <thread>         // std::thread
+#include <memory>
+#include <vector>
+#include <future>
+
+//monoDrive Includes
+#include "Simulator.h"
+#include "Configuration.h"  // holder for sensor, simulator, scenario, weather, and vehicle configurations
+#include "Sensor.h"
+#include "sensor_config.h"
+
+#include "opencv2/core.hpp"
+#include "opencv2/core/utility.hpp"
+#include "opencv2/highgui.hpp"
+#include "opencv2/imgproc.hpp"
+
+#define IMG_WIDTH 1920
+#define IMG_HEIGHT 1080
+
+int main(int argc, char** argv)
+{
+    //Single Simulator Example
+    std::string server0_ip = "127.0.0.1";
+    int server_port = 8999;   // This has to be 8999 this simulator is listening for connections on this port;
+
+    Configuration config(
+        "examples/config/simulator_imager.json",
+        "examples/config/weather.json",
+        "examples/config/imager.json"
+    );
+    // swap to this for interesting scenario with a fisheye camera
+    Simulator sim0(config, server0_ip, server_port);
+
+    // Configure simulator
+    if(!sim0.configure()){
+        return -1;
+    }
+
+    // Configure the sensors we wish to use
+    std::vector<std::shared_ptr<Sensor>> sensors;
+
+    CameraConfig fc_config;
+    fc_config.resolution = Resolution(IMG_WIDTH,IMG_HEIGHT);
+    fc_config.server_ip = sim0.getServerIp();
+    fc_config.server_port = sim0.getServerPort();
+    fc_config.listen_port = 8100;
+    fc_config.location.x = 70;
+    fc_config.location.z = 170;
+    // fc_config.color_filter_array.cfa = "rccc";
+    fc_config.color_filter_array.cfa = "rggb";
+    fc_config.color_filter_array.use_cfa = true;
+
+    // configure viewport settings for hdmi streaming, uncomment to stream to HDMI
+    // fc_config.viewport.enable_viewport = true;
+    // fc_config.viewport.fullscreen = true;
+    // fc_config.viewport.window_size = Resolution(IMG_WIDTH,IMG_HEIGHT);
+    // 0 is main monitor starting from the left
+    // fc_config.viewport.monitor_number = 1;
+    sensors.push_back(std::make_shared<Sensor>(std::make_unique<CameraConfig>(fc_config)));
+
+    CameraConfig rgb_config;
+    rgb_config.server_ip = sim0.getServerIp();
+    rgb_config.server_port = sim0.getServerPort();
+    rgb_config.listen_port = 8101;
+    rgb_config.location.x = 70;
+    rgb_config.location.z = 170;
+    rgb_config.resolution = Resolution(IMG_WIDTH,IMG_HEIGHT);
+    sensors.push_back(std::make_shared<Sensor>(std::make_unique<CameraConfig>(rgb_config)));
+
+    ViewportCameraConfig vp_config;
+    vp_config.server_ip = sim0.getServerIp();
+    vp_config.server_port = sim0.getServerPort();
+    vp_config.location.z = 200;
+    vp_config.resolution = Resolution(256,256);
+    Sensor(std::make_unique<ViewportCameraConfig>(vp_config)).configure();
+
+    // Send configurations to the simulator
+    std::cout<<"***********ALL SENSOR's CONFIGS*******"<<std::endl;
+    for (auto& sensor : sensors)
+    {
+        sensor->configure();
+    }
+
+    int count1 = 0;
+    sensors[0]->sampleCallback = [&count1](DataFrame *frame) {
+        auto camFrame = static_cast<CameraFrame*>(frame);
+        auto imFrame = camFrame->imageFrame;
+        cv::Mat img;
+        if (imFrame->channels == 4)
+        {
+            img = cv::Mat(imFrame->resolution.y, imFrame->resolution.x, CV_8UC4,
+                          imFrame->pixels);
+        }
+        else
+            return;
+        
+        // just to make the rgb image smaller when saved
+        cv::cvtColor(img, img, cv::COLOR_BGRA2BGR);
+        // std::cout << (int)img.at<cv::Vec3b>(0,0)[0] << " " 
+        //     << (int)img.at<cv::Vec3b>(0,0)[1] << " " 
+        //     << (int)img.at<cv::Vec3b>(0,0)[2] << " " <<std::endl;
+        cv::Mat1b rggb;
+        cv::extractChannel(img, rggb, 2); 
+        std::cout << rggb.size() << std::endl;
+
+        cv::Mat color;
+        cv::cvtColor(rggb, color, cv::COLOR_BayerBG2BGR);
+        if(count1++ == 50){
+            // saving a copy of one of the streamed images
+            cv::imwrite("de_bayered.png", color);
+            cv::imwrite("bayer.png", rggb);
+        }
+        cv::imshow("de-bayered", color);
+        cv::imshow("bayer", rggb);
+        cv::waitKey(1);
+    };
+    // an rgb rendered image for comparison
+    int count2 = 0;
+    sensors[1]->sampleCallback = [&count2](DataFrame *frame) {
+        auto camFrame = static_cast<CameraFrame*>(frame);
+        auto imFrame = camFrame->imageFrame;
+        cv::Mat img;
+        if (imFrame->channels == 4)
+        {
+            img = cv::Mat(imFrame->resolution.y, imFrame->resolution.x, CV_8UC4,
+                          imFrame->pixels);
+        }
+        else
+            return;
+        if(count2++ == 50){
+            cv::imwrite("rgb.png", img);
+        }
+        cv::imshow("rgb", img);
+        cv::waitKey(1);
+    };
+
+    std::cout << "Sampling sensor loop" << std::endl;
+    while(true)
+    {
+        sim0.sampleAll(sensors);
+    }
+
+    return 0;
+}

--- a/monodrive/core/src/Simulator.cpp
+++ b/monodrive/core/src/Simulator.cpp
@@ -98,22 +98,23 @@ void Simulator::clearInstances()
 
 bool Simulator::connect()
 {
+	bool success = true;
 	if(!controlSocket.is_open())
 	{
-		std::cout << "******Simulator Connect********" << std::endl;
+		std::cout << "******Simulator Connect " << serverIp << ":" << serverPort << "********" << std::endl;
 		try{
-		const auto ipaddress = boost::asio::ip::address::from_string(serverIp);
-		const auto endpoint = boost::asio::ip::tcp::endpoint(ipaddress, serverPort);
-		std::cout << endpoint << std::endl;
-		controlSocket.connect(endpoint);
+			const auto ipaddress = boost::asio::ip::address::from_string(serverIp);
+			const auto endpoint = boost::asio::ip::tcp::endpoint(ipaddress, serverPort);
+			controlSocket.connect(endpoint);
+			success = true;
 		}
 		catch (const std::exception& e){
 			std::cerr << "ERROR! Failed to connect to server. Is it running?" << std::endl;
 			std::cerr << e.what() << std::endl;
-			return false;
+			success = false;
 		}
 	}
-	return true;
+	return success;
 }
 
 void Simulator::stop()
@@ -127,8 +128,9 @@ void Simulator::stop()
 bool Simulator::configure()
 {
 	using namespace std;
-	if(!connect())
+	if(!connect()){
 		return false;
+	}
 
 	if(config.simulator.empty())
 	{

--- a/monodrive/core/src/Simulator.h
+++ b/monodrive/core/src/Simulator.h
@@ -59,9 +59,9 @@ public:
 	const std::string& getServerIp() const{return serverIp;}
 	const short& getServerPort() const{return serverPort;}
 	Simulator(const std::string& serverIp, const short& serverPort);
+	Simulator(const Configuration& config, const std::string& serverIp, const short& serverPort);
 private:
 	Simulator(const Configuration& config);
-	Simulator(const Configuration& config, const std::string& serverIp, const short& serverPort);
 	Simulator(const Simulator&)= delete;
 	void waitForSamples(const std::vector<std::shared_ptr<Sensor>>& sensors);
   	Simulator& operator=(const Simulator&)= delete;

--- a/monodrive/core/src/sensor_config.h
+++ b/monodrive/core/src/sensor_config.h
@@ -543,6 +543,7 @@ void inline to_json(nlohmann::json& j, const CameraConfig& config)
     j["channels"] = config.channels;
     j["channel_depth"] = config.channel_depth;
     j["annotation"] = config.annotation;
+    j["color_filter_array"] = config.color_filter_array;
     j["viewport"] = config.viewport;
 }
 
@@ -563,6 +564,7 @@ void inline from_json(const nlohmann::json& j, CameraConfig& config)
     json_get(j, "channels", config.channels);         
     json_get(j, "channel_depth", config.channel_depth);         
     json_get(j, "annotation", config.annotation);
+    json_get(j, "color_filter_array", config.color_filter_array);
     json_get(j, "viewport", config.viewport);
 }
 

--- a/monodrive/core/src/sensor_config.h
+++ b/monodrive/core/src/sensor_config.h
@@ -207,6 +207,10 @@ public:
         bool cull_partial_frame{false};
         bool debug_draw{false};
     } annotation;
+    struct ColorFilterArray {
+        bool use_cfa{false};
+        std::string cfa{"rccc"};
+    } color_filter_array;
     Viewport viewport;
     virtual DataFrame* DataFrameFactory() override{
         int nChannels = 4;
@@ -509,6 +513,17 @@ void inline from_json(const nlohmann::json& j, CameraConfig::Annotation& annotat
     json_get(j, "include_obb", annotation.include_oob);
     json_get(j, "include_tags", annotation.include_tags);
     json_get(j, "debug_draw", annotation.debug_draw);
+}
+
+void inline to_json(nlohmann::json& j, const CameraConfig::ColorFilterArray& cfa) {
+    j = nlohmann::json{
+        {"cfa", cfa.cfa},
+        {"use_cfa", cfa.use_cfa}
+    };
+}
+void inline from_json(const nlohmann::json& j, CameraConfig::ColorFilterArray& cfa) {
+    json_get(j, "cfa", cfa.cfa);
+    json_get(j, "use_cfa", cfa.use_cfa);
 }
 
 /// Camera Config JSON Parsing

--- a/monodrive/core/src/sensor_config.h
+++ b/monodrive/core/src/sensor_config.h
@@ -214,7 +214,7 @@ public:
     Viewport viewport;
     virtual DataFrame* DataFrameFactory() override{
         int nChannels = 4;
-        if(channels.compare("bgra") == 0 || channels.compare("rgba") == 0)
+        if(channels.compare("bgra") == 0 || channels.compare("rgba") == 0 || color_filter_array.use_cfa)
             nChannels = 4;
         else if(channels.compare("gray") == 0)
             nChannels = 1;


### PR DESCRIPTION
## Overview
Adds Color Filter Array (Bayer for example) imaging options to the CameraSensor (not added for fisheye yet).
Note that in the example I use the Simulator constructor rather than the singleton class. The singleton class prevents connection errors from being seen by the user program. This way if the Server is not available we can correctly early exit and warn user instead of creashing.

## Changes

- Adds 2 examples one for RGGB and one for RCCC.
- Adds sensor config option color_filter_array: use_cfa, cfa which enable color filter array output. CFA will output an RGBA image with the R encoded with the value and rest set to 0. Would have liked to send just a grayscale image but time did not permit.

## Testing
Run the two imager examples. 
For RGGB example: should get 3 screens for RGGB, 1 RGB, 1 RGB from Bayer, 1 Grayscale Bayer
For RCCC example: should get 2 screens, 1 Grayscale Bayer, 1 Grayscale
