### PR TITLE
Added parllel build option for MSVC compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.10)
 
 project(monodrive_clients)
 
+# Enable multi-core building in VS/Code
+include(ProcessorCount)
+if(MSVC)
+  ProcessorCount(PROC_COUNT)
+  # This explicitly sets the job count because the current CMake interface -j8 
+  # or --parllel does not work with MSVC. We can fix this when this issue is 
+  # resolved: https://gitlab.kitware.com/cmake/cmake/-/issues/20564 
+  if(NOT PROC_COUNT EQUAL 0) 
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP${PROC_COUNT}")
+  endif()
+endif()
+
 add_subdirectory(monodrive)
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7)
   add_subdirectory(examples)


### PR DESCRIPTION
## Overview
With MSVC 16.3 and beyond, parallelism has changed and no longer obeys CMake `-j` or `--parallel` flags for compiling objects, only for compiling projects. This explicitly sets MSVC compiler flag to the total number of processors because
![unnamed](https://user-images.githubusercontent.com/6026642/98997773-adb9f000-24fa-11eb-99cd-9394e2a5031a.jpg)

## Changes
* Enable compiler flag.

## Testing
* Build the project
* ![The-car-is-really-fast_fb_9055](https://user-images.githubusercontent.com/6026642/98997862-d80bad80-24fa-11eb-8dc9-60fcb9e788cd.jpg)

